### PR TITLE
remove needless use of multiplicative identity op

### DIFF
--- a/Domain/Scheduling/EventSourcedRepositoryExtensions.cs
+++ b/Domain/Scheduling/EventSourcedRepositoryExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Its.Domain
             {
                 if (failure.NumberOfPreviousAttempts < 5)
                 {
-                    failure.Retry(TimeSpan.FromMinutes(1*(failure.NumberOfPreviousAttempts + 1)));
+                    failure.Retry(TimeSpan.FromMinutes(failure.NumberOfPreviousAttempts + 1));
                 }
             }
 


### PR DESCRIPTION
Was just poking around your implementation of command scheduling and noticed this.  Are there side effects to the op that I might be overlooking?