### PR TITLE
Apply scheduled commands async

### DIFF
--- a/Domain/Scheduling/EventSourcedRepositoryExtensions.cs
+++ b/Domain/Scheduling/EventSourcedRepositoryExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Its.Domain
                 }
                 else
                 {
-                    aggregate.Apply(scheduled.Command);
+                    await aggregate.ApplyAsync(scheduled.Command);
                 }
 
                 repository.Save(aggregate);


### PR DESCRIPTION
I think this is a left over problem with the TPL and scheduling commands. ApplyAsync should be used everywhere by default now no?