### PR TITLE
fix bug where sqlCommandScheduler could pick up the wrong command to …

### DIFF
--- a/AssemblyInfoVersion.cs
+++ b/AssemblyInfoVersion.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved. 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion("0.11.5.0")]
-[assembly: AssemblyFileVersion("0.11.13-beta")]
+[assembly: AssemblyFileVersion("0.11.14-beta")]

--- a/Domain.Api/Microsoft.Its.Domain.Api.nuspec
+++ b/Domain.Api/Microsoft.Its.Domain.Api.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain.Api</id>
     <title>Its.Domain.Api</title>
-    <version>0.11.13-beta</version>
+    <version>0.11.14-beta</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,7 +11,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>webapi DDD CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.13-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.14-beta,1)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)"  />
       <dependency id="Rx-Main" version="[2.2.5,)"   />
     </dependencies>

--- a/Domain.Sql/CommandScheduler/SqlCommandSchedulerBinder{T}.cs
+++ b/Domain.Sql/CommandScheduler/SqlCommandSchedulerBinder{T}.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
         {
             var command = scheduled.ToScheduledCommand<TAggregate>();
 
+            //here we are setting the command.SequenceNumber to the scheduled.SequenceNumber because when
+            //multiple commands are scheduled simultaniously against the same aggregate we were decrementing the 
+            //scheduled.SequenceNumber correctly, however we were not updating the command.SequenceNumber.
+            //this is to prevent any side effects that may have been caused by that bug
+            command.SequenceNumber = scheduled.SequenceNumber;
+
             await scheduler.Deliver(command);
 
             scheduled.Result = command.Result;

--- a/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
+++ b/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain.Sql</id>
     <title>Its.Domain.Sql</title>
-    <version>0.11.13-beta</version>
+    <version>0.11.14-beta</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,7 +11,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>SQL CQRS Its.Cqrs event-sourcing</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.13-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.14-beta,1)" />
       <dependency id="EntityFramework" version="[6,)" />
       <dependency id="Its.Validation" version="[1.1.5,2.0)" />
     </dependencies>

--- a/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
+++ b/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain.Testing</id>
     <title>Its.Domain.Testing</title>
-    <version>0.11.13-beta</version>
+    <version>0.11.14-beta</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,8 +11,8 @@
     <copyright>Copyright 2015</copyright>
     <tags>testing CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.13-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.11.13-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.14-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.11.14-beta,1)" />
       <dependency id="Rx-Main" version="[2.2.5,)" />
     </dependencies>
   </metadata>

--- a/Domain/Microsoft.Its.Domain.nuspec
+++ b/Domain/Microsoft.Its.Domain.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain</id>
     <title>Its.Domain</title>
-    <version>0.11.13-beta</version>
+    <version>0.11.14-beta</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur,Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Recipes/Its.Domain.ServiceBusCommandScheduling.nuspec
+++ b/Recipes/Its.Domain.ServiceBusCommandScheduling.nuspec
@@ -12,8 +12,8 @@
     <tags>Its.Cqrs CQRS ServiceBus Azure</tags>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.13-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.11.13-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.14-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.11.14-beta,1)" />
       <dependency id="Its.Recipes-ServiceBusConfiguration" version="[0.4.0,1)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
when multiple commands were scheduled simultaneously against the same aggregate at the exact same time all commands would attempt to use the same sequence number. in this event, the command scheduler would decrement the sequence number of some and try again until success. 

this however, did not update the sequence number in the serialized command in the scheduled command db. this would cause the wrong command to be picked up for delivery at times. made a fix to always use the decremented sequence number to pull up the right command.