### PR TITLE
Consolidate NuGet package version specifications

### DIFF
--- a/AssemblyInfoVersion.cs
+++ b/AssemblyInfoVersion.cs
@@ -3,5 +3,9 @@
 
 using System.Reflection;
 
+// Don't edit this version.
 [assembly: AssemblyVersion("0.11.5.0")]
+
+// Edit these for each release + update dependencies in .nuspec files
 [assembly: AssemblyFileVersion("0.11.14-beta")]
+[assembly: AssemblyInformationalVersion("0.11.14-beta")]

--- a/Domain.Api/Microsoft.Its.Domain.Api.nuspec
+++ b/Domain.Api/Microsoft.Its.Domain.Api.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain.Api</id>
     <title>Its.Domain.Api</title>
-    <version>0.11.14-beta</version>
+    <version>$version$</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
+++ b/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain.Sql</id>
     <title>Its.Domain.Sql</title>
-    <version>0.11.14-beta</version>
+    <version>$version$</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
+++ b/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain.Testing</id>
     <title>Its.Domain.Testing</title>
-    <version>0.11.14-beta</version>
+    <version>$version$</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Domain/Microsoft.Its.Domain.nuspec
+++ b/Domain/Microsoft.Its.Domain.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Domain</id>
     <title>Its.Domain</title>
-    <version>0.11.14-beta</version>
+    <version>$version$</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur,Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Its.Cqrs.sln
+++ b/Its.Cqrs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "Domain\Domain.csproj", "{99442ACC-A914-4BDF-8DE5-D074FA0447F5}"
 EndProject
@@ -46,6 +46,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{A9C8A1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{161ACB04-1D76-4173-A6FE-99D761CA47FC}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		AssemblyInfoVersion.cs = AssemblyInfoVersion.cs
+		buildNuget.ps1 = buildNuget.ps1
+		nuget.config = nuget.config
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Banking.Domain", "Samples\Banking\Banking.Domain\Banking.Domain.csproj", "{0388601C-B785-498D-92DE-5B8C376728C0}"
 EndProject

--- a/buildNuget.ps1
+++ b/buildNuget.ps1
@@ -1,5 +1,5 @@
 rm -Force -Recurse .\NuGet
-mkdir NuGet
+mkdir NuGet | Out-Null
 
 @(
 	".\Domain\Domain.csproj", 


### PR DESCRIPTION
NuGet can get it from assembly metadata, looking at the `AssemblyInformationalVersion` attribute.