### PR TITLE
Increase create database sql script timeout to 10 minutes

### DIFF
--- a/AssemblyInfoVersion.cs
+++ b/AssemblyInfoVersion.cs
@@ -7,5 +7,5 @@ using System.Reflection;
 [assembly: AssemblyVersion("0.11.5.0")]
 
 // Edit these for each release + update dependencies in .nuspec files
-[assembly: AssemblyFileVersion("0.11.15-beta")]
-[assembly: AssemblyInformationalVersion("0.11.15-beta")]
+[assembly: AssemblyFileVersion("0.11.16-beta")]
+[assembly: AssemblyInformationalVersion("0.11.16-beta")]

--- a/Domain.Api/Microsoft.Its.Domain.Api.nuspec
+++ b/Domain.Api/Microsoft.Its.Domain.Api.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>webapi DDD CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.15-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.16-beta,1)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)"  />
       <dependency id="Rx-Main" version="[2.2.5,)"   />
     </dependencies>

--- a/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
+++ b/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>SQL CQRS Its.Cqrs event-sourcing</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.15-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.16-beta,1)" />
       <dependency id="EntityFramework" version="[6,)" />
       <dependency id="Its.Validation" version="[1.1.5,2.0)" />
     </dependencies>

--- a/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
+++ b/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
@@ -11,8 +11,8 @@
     <copyright>Copyright 2015</copyright>
     <tags>testing CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.15-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.11.15-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.16-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.11.16-beta,1)" />
       <dependency id="Rx-Main" version="[2.2.5,)" />
     </dependencies>
   </metadata>

--- a/Recipes/Its.Domain.ServiceBusCommandScheduling.nuspec
+++ b/Recipes/Its.Domain.ServiceBusCommandScheduling.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Its.Recipes-Its.Domain.ServiceBusCommandScheduling</id>
     <title>Its.Recipes - Azure Service Bus Command Scheduling</title>
-    <version>0.4.0-beta</version>
+    <version>0.4.1-beta</version>
     <authors>Microsoft,jonsequitur</authors>
     <owners>Microsoft,jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/Its.Cqrs</projectUrl>
@@ -12,8 +12,8 @@
     <tags>Its.Cqrs CQRS ServiceBus Azure</tags>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.15-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.11.15-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.16-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.11.16-beta,1)" />
       <dependency id="Its.Recipes-ServiceBusConfiguration" version="[0.4.0,1)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
With Azure SQL DB V12, the database creation SQL command is blocked until the creation is finished. So increase the SQL command timeout to 10 minutes.