### PR TITLE
Fix serialization error when recording projection errors

### DIFF
--- a/Domain/Serialization/Serializer.cs
+++ b/Domain/Serialization/Serializer.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Its.Domain.Serialization
                 NullValueHandling = NullValueHandling.Include,
                 ContractResolver = new OptionalContractResolver(),
                 DefaultValueHandling = DefaultValueHandling.Include,
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                Error = (sender, args) => args.ErrorContext.Handled = true
             };
 
             AddConverter(new OptionalConverter());


### PR DESCRIPTION
- Remove SerializedEvent from ReadModelInfo.Error column. Use FailedOnEventId = EventHandlingErrors.OriginalId to find the full details. This has the benefit of making the Error column in both tables have the same shape.

- Make ToDiagnosticJson() tolerate exceptions.

- Switch from ToJson() to ToDiagnosticJson() for recording exceptions, since ToJson() doesn't (and shouldn't) tolerate exceptions.

- Let Log.Write() handle the details of how it serializes for logging