### PR TITLE
Revert 237cd31 - "make EventSourcedAggregate.ETags internal"

### DIFF
--- a/AssemblyInfoVersion.cs
+++ b/AssemblyInfoVersion.cs
@@ -7,5 +7,5 @@ using System.Reflection;
 [assembly: AssemblyVersion("0.11.5.0")]
 
 // Edit these for each release + update dependencies in .nuspec files
-[assembly: AssemblyFileVersion("0.11.19-beta")]
-[assembly: AssemblyInformationalVersion("0.11.19-beta")]
+[assembly: AssemblyFileVersion("0.11.20-beta")]
+[assembly: AssemblyInformationalVersion("0.11.20-beta")]

--- a/Domain.Api/Microsoft.Its.Domain.Api.nuspec
+++ b/Domain.Api/Microsoft.Its.Domain.Api.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>webapi DDD CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.19-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.20-beta,1)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)"  />
       <dependency id="Rx-Main" version="[2.2.5,)"   />
     </dependencies>

--- a/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
+++ b/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2015</copyright>
     <tags>SQL CQRS Its.Cqrs event-sourcing</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.19-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.20-beta,1)" />
       <dependency id="EntityFramework" version="[6,)" />
       <dependency id="Its.Validation" version="[1.1.5,2.0)" />
     </dependencies>

--- a/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
+++ b/Domain.Testing/Microsoft.Its.Domain.Testing.nuspec
@@ -11,8 +11,8 @@
     <copyright>Copyright 2015</copyright>
     <tags>testing CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.19-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.11.19-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.20-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.11.20-beta,1)" />
       <dependency id="Rx-Main" version="[2.2.5,)" />
     </dependencies>
   </metadata>

--- a/Domain/EventSourcedAggregate.cs
+++ b/Domain/EventSourcedAggregate.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Its.Domain
             return ETags().Any(e => e == etag);
         }
 
-        internal IEnumerable<string> ETags()
+        public IEnumerable<string> ETags()
         {
             return sourceSnapshot.IfNotNull()
                                  .Then(s => s.ETags)

--- a/Recipes/Its.Domain.ServiceBusCommandScheduling.nuspec
+++ b/Recipes/Its.Domain.ServiceBusCommandScheduling.nuspec
@@ -12,8 +12,8 @@
     <tags>Its.Cqrs CQRS ServiceBus Azure</tags>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.11.19-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.11.19-beta,1)" />
+      <dependency id="Its.Domain" version="[0.11.20-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.11.20-beta,1)" />
       <dependency id="Its.Recipes-ServiceBusConfiguration" version="[0.4.0,1)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
This breaks compatibility with existing clients.

    commit 237cd3148ee19e8211a3fee6cb928bc501b197d7
    Author: jonsequitur <jonsequeira@gmail.com>
    Date:   Wed Aug 26 15:18:26 2015 -0700