### PR TITLE
Update the systemclock to use UtcNow. 

### DIFF
--- a/Domain/SystemClock.cs
+++ b/Domain/SystemClock.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Its.Domain
         /// </summary>
         public DateTimeOffset Now()
         {
-            return DateTimeOffset.Now;
+            return DateTimeOffset.UtcNow;
         }
 
         public override string ToString()


### PR DESCRIPTION
This is because some of code uses Month, Year properties of DateTimeOffset. At the end of month, the Month, Year properties will be different between DateTimeOffset.Now and DateTimeOffset.UtcNow.