### PR TITLE
Remove transaction scope handling

### DIFF
--- a/Domain.Sql/EventHandlerProgressCalculator.cs
+++ b/Domain.Sql/EventHandlerProgressCalculator.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Its.Domain.Sql
 
             int count;
 
-            using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             using (var db = createEventStoreDbContext.IfNotNull()
                                                      .Then(create => create())
                                                      .Else(() => new EventStoreDbContext()))
@@ -40,7 +39,7 @@ namespace Microsoft.Its.Domain.Sql
             var progress = new List<EventHandlerProgress>();
 
             ReadModelInfo[] readModelInfos;
-            using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
+
             using (var db = createDbContext())
             {
                 readModelInfos = db.Set<ReadModelInfo>().ToArray();

--- a/Domain.Sql/SqlEventSourcedRepository{T}.cs
+++ b/Domain.Sql/SqlEventSourcedRepository{T}.cs
@@ -52,7 +52,6 @@ namespace Microsoft.Its.Domain.Sql
                                               .GetSnapshot(id, version, asOfDate);
             }
 
-            using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             using (var context = GetEventStoreContext())
             {
                 var streamName = AggregateType<TAggregate>.EventStreamName;
@@ -137,7 +136,6 @@ namespace Microsoft.Its.Domain.Sql
         {
             IEvent[] events;
 
-            using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
             using (var context = GetEventStoreContext())
             {
                 var streamName = AggregateType<TAggregate>.EventStreamName;

--- a/Domain.Sql/SqlEventSourcedRepository{T}.cs
+++ b/Domain.Sql/SqlEventSourcedRepository{T}.cs
@@ -188,12 +188,6 @@ namespace Microsoft.Its.Domain.Sql
                 return storableEvent;
             }).ToArray();
 
-            using (var tran = new TransactionScope(TransactionScopeOption.RequiresNew,
-                                                   new TransactionOptions
-                                                   {
-                                                       IsolationLevel = IsolationLevel.ReadCommitted
-                                                   }, 
-                                                   TransactionScopeAsyncFlowOption.Enabled))
             using (var context = GetEventStoreContext())
             {
                 foreach (var storableEvent in storableEvents)
@@ -219,7 +213,6 @@ namespace Microsoft.Its.Domain.Sql
                 try
                 {
                     await context.SaveChangesAsync();
-                    tran.Complete();
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
removing manual handling of the Transaction scope related to EF operations. this is required because EF execution strategies (sqlAzure specifically) doesnt let you control the transaction scope yourself.

details here: http://go.microsoft.com/fwlink/?LinkId=309381 