### PR TITLE
Update Domain.Sql nuspec EF version

### DIFF
--- a/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
+++ b/Domain.Sql/Microsoft.Its.Domain.Sql.nuspec
@@ -12,7 +12,7 @@
     <tags>SQL CQRS Its.Cqrs event-sourcing</tags>
     <dependencies>
       <dependency id="Its.Domain" version="[0.12.8-beta,1)" />
-      <dependency id="EntityFramework" version="[6,)" />
+      <dependency id="EntityFramework" version="[6.1.3,)" />
       <dependency id="Its.Validation" version="[1.1.5,2.0)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Raising the minimum version of Entity Framework required from 6.0 to 6.1.3.