### PR TITLE
change RecordEvent to return the event rather than void

### DIFF
--- a/Domain.Tests/MarcoPolo.cs
+++ b/Domain.Tests/MarcoPolo.cs
@@ -57,13 +57,15 @@ namespace Microsoft.Its.Domain.Tests
 
             public async Task EnactCommand(MarcoPoloPlayerWhoIsIt it, SayMarco command)
             {
+                var saidMarco = it.RecordEvent(new SaidMarco());
+
                 var scheduleTasks =
                     it.playerIds.Select(playerId => playerScheduler.Schedule(
                         playerId,
                         new MarcoPoloPlayerWhoIsNotIt.SayPolo
                         {
                             IdOfPlayerWhoIsIt = it.Id
-                        }, deliveryDependsOn: it.RecordEvent(new SaidMarco())));
+                        }, deliveryDependsOn: saidMarco));
 
                 await Task.WhenAll(scheduleTasks);
             }

--- a/Domain.Tests/MarcoPolo.cs
+++ b/Domain.Tests/MarcoPolo.cs
@@ -57,17 +57,13 @@ namespace Microsoft.Its.Domain.Tests
 
             public async Task EnactCommand(MarcoPoloPlayerWhoIsIt it, SayMarco command)
             {
-                var saidMarco = new SaidMarco();
-
-                it.RecordEvent(saidMarco);
-
                 var scheduleTasks =
                     it.playerIds.Select(playerId => playerScheduler.Schedule(
                         playerId,
                         new MarcoPoloPlayerWhoIsNotIt.SayPolo
                         {
                             IdOfPlayerWhoIsIt = it.Id
-                        }, deliveryDependsOn: saidMarco));
+                        }, deliveryDependsOn: it.RecordEvent(new SaidMarco())));
 
                 await Task.WhenAll(scheduleTasks);
             }

--- a/Domain/EventSourcedAggregate{T}.cs
+++ b/Domain/EventSourcedAggregate{T}.cs
@@ -65,10 +65,11 @@ namespace Microsoft.Its.Domain
         ///     Records an event, updating the aggregate's state and adding the event to PendingEvents.
         /// </summary>
         /// <remarks>It is not necessary to specify the AggregateId or SequenceNumber properties on the recorded event. The <see cref="EventSourcedAggregate" /> class handles this.</remarks>
-        protected void RecordEvent(Event<T> e)
+        protected Event<T> RecordEvent(Event<T> e)
         {
             AddPendingEvent(e);
-            e.Update((T) this);
+            e.Update((T)this);
+            return e;
         }
 
         /// <summary>

--- a/Sample.Domain/Ordering/Order.EnactCommand.cs
+++ b/Sample.Domain/Ordering/Order.EnactCommand.cs
@@ -73,10 +73,6 @@ namespace Sample.Domain.Ordering
 
             public async Task EnactCommand(Order order, Cancel cancel)
             {
-                var cancelled = new Cancelled();
-
-                order.RecordEvent(cancelled);
-
                 var command = new NotifyOrderCanceled
                 {
                     OrderNumber = order.OrderNumber
@@ -84,8 +80,8 @@ namespace Sample.Domain.Ordering
 
                 await scheduler.Schedule(
                     order.CustomerId, 
-                    command, 
-                    deliveryDependsOn: cancelled);
+                    command,
+                    deliveryDependsOn: order.RecordEvent(new Cancelled()));
             }
 
             public async Task HandleScheduledCommandException(Order order, CommandFailed<Cancel> command)

--- a/Samples/Banking/Banking.Domain/CheckingAccount/Events/CheckingAccount.FundsWithdrawn.cs
+++ b/Samples/Banking/Banking.Domain/CheckingAccount/Events/CheckingAccount.FundsWithdrawn.cs
@@ -14,6 +14,10 @@ namespace Sample.Banking.Domain
             public override void Update(CheckingAccount aggregate)
             {
                 aggregate.Balance -= Amount;
+                if (aggregate.Balance <= 0)
+                {
+                    aggregate.IsOverdrawn = true;
+                }
             }
         }
     }


### PR DESCRIPTION
as shown in the MarcoPolo.cs class i altered below i felt this flowed a bit better and reduced the need for as much boiler plate code.

thoughts?

also set a property that wasn't being set in the bank example.