### PR TITLE
Changing [IX_Id_and_Type] to include StreamName

### DIFF
--- a/Domain.Sql/Migrations/EventStoreDbContext-0_14_0.sql
+++ b/Domain.Sql/Migrations/EventStoreDbContext-0_14_0.sql
@@ -24,11 +24,12 @@ end
 
 if not exists(select * from sys.indexes where name='IX_Id_and_Type' and object_id = OBJECT_ID('eventstore.events'))
 begin
-	CREATE NONCLUSTERED INDEX [IX_Id_and_Type] ON [EventStore].[Events]
+	CREATE NONCLUSTERED INDEX [IX_Id_and_Type] ON [EventStore].[Events] 
 	(
-	    [Id] ASC,
+		[Id] ASC,
 		[Type] ASC
-	)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+	)
+	INCLUDE ([StreamName])
 end
 
 


### PR DESCRIPTION
Looking at query plans with Chris, including StreamName in the index resulted in being able to go entirely off of the index for the catchup query.