### PR TITLE
Fix for issue #124

### DIFF
--- a/Domain.Api.Tests/(Pocket)/PocketContainer.cs
+++ b/Domain.Api.Tests/(Pocket)/PocketContainer.cs
@@ -113,7 +113,18 @@ namespace Pocket
             Func<PocketContainer, object> func;
             if (!resolvers.TryGetValue(type, out func))
             {
-                return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                try
+                {
+                    return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null   )
+                    {
+                        throw ex.InnerException;
+                    }
+                    throw;
+                }
             }
             return func(this);
         }

--- a/Domain.Api.Tests/packages.config
+++ b/Domain.Api.Tests/packages.config
@@ -13,7 +13,7 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="PocketContainer" version="1.2.6" targetFramework="net451" developmentDependency="true" />
+  <package id="PocketContainer" version="1.2.7" targetFramework="net452" developmentDependency="true" />
   <package id="PocketContainer.WebApiDependencyResolver" version="1.0.6" targetFramework="net451" developmentDependency="true" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/Domain.Sql.Tests/(Pocket)/PocketContainer.cs
+++ b/Domain.Sql.Tests/(Pocket)/PocketContainer.cs
@@ -113,7 +113,18 @@ namespace Pocket
             Func<PocketContainer, object> func;
             if (!resolvers.TryGetValue(type, out func))
             {
-                return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                try
+                {
+                    return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null   )
+                    {
+                        throw ex.InnerException;
+                    }
+                    throw;
+                }
             }
             return func(this);
         }

--- a/Domain.Sql.Tests/SqlCommandSchedulerTests.cs
+++ b/Domain.Sql.Tests/SqlCommandSchedulerTests.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Its.Domain.Sql.Tests
 
         public abstract Task Scheduled_commands_are_delivered_immediately_if_past_due_per_the_scheduler_clock();
 
+        public abstract Task Scheduled_commands_with_no_due_time_set_the_correct_clock_time_when_delivery_is_deferred();
+
         public abstract Task A_command_handler_can_request_retry_of_a_failed_command_as_soon_as_possible();
 
         public abstract Task A_command_handler_can_request_retry_of_a_failed_command_as_late_as_it_wants();
@@ -44,5 +46,6 @@ namespace Microsoft.Its.Domain.Sql.Tests
         public abstract Task When_command_is_durable_but_immediate_delivery_succeeds_then_it_is_not_redelivered();
 
         public abstract Task When_a_clock_is_advanced_and_a_command_fails_to_be_deserialized_then_other_commands_are_still_applied();
+        public abstract Task Immediately_scheduled_commands_triggered_by_a_scheduled_command_have_their_due_time_set_to_the_causative_command_clock();
     }
 }

--- a/Domain.Sql.Tests/packages.config
+++ b/Domain.Sql.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="PocketContainer" version="1.2.6" targetFramework="net451" developmentDependency="true" />
+  <package id="PocketContainer" version="1.2.7" targetFramework="net452" developmentDependency="true" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />

--- a/Domain.Sql/CommandScheduler/ScheduledCommand.cs
+++ b/Domain.Sql/CommandScheduler/ScheduledCommand.cs
@@ -58,16 +58,6 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
                              .IfHas(d => d.DeliveryPrecondition)
                              .ElseDefault();
 
-        IClock IScheduledCommand.Clock
-        {
-            get
-            {
-                return Clock;
-            }
-            set
-            {
-                Clock = (Clock) value;
-            }
-        }
+        IClock IScheduledCommand.Clock => Clock;
     }
 }

--- a/Domain.Sql/CommandScheduler/ScheduledCommand.cs
+++ b/Domain.Sql/CommandScheduler/ScheduledCommand.cs
@@ -58,6 +58,16 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
                              .IfHas(d => d.DeliveryPrecondition)
                              .ElseDefault();
 
-        IClock IScheduledCommand.Clock => Clock;
+        IClock IScheduledCommand.Clock
+        {
+            get
+            {
+                return Clock;
+            }
+            set
+            {
+                Clock = (Clock) value;
+            }
+        }
     }
 }

--- a/Domain.Sql/CommandScheduler/ScheduledCommand.cs
+++ b/Domain.Sql/CommandScheduler/ScheduledCommand.cs
@@ -57,5 +57,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
             SerializedCommand.FromJsonTo<JObject>()
                              .IfHas(d => d.DeliveryPrecondition)
                              .ElseDefault();
+
+        IClock IScheduledCommand.Clock => Clock;
     }
 }

--- a/Domain.Sql/CommandScheduler/SqlCommandSchedulerExtensions.cs
+++ b/Domain.Sql/CommandScheduler/SqlCommandSchedulerExtensions.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
 
             var command = json.FromJsonTo<ScheduledCommand<TAggregate>>();
 
+            command.Clock = scheduled.Clock;
+            command.DueTime = scheduled.DueTime;
             command.SequenceNumber = scheduled.SequenceNumber;
-
             command.NumberOfPreviousAttempts = scheduled.Attempts;
 
             return command;

--- a/Domain.Sql/CommandScheduler/SqlCommandSchedulerPipelineInitializer{T}.cs
+++ b/Domain.Sql/CommandScheduler/SqlCommandSchedulerPipelineInitializer{T}.cs
@@ -48,10 +48,14 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
             Func<IScheduledCommand<TAggregate>, Task> next)
             where TAggregate : class
         {
-            IClock clock = null;
+            IClock clock;
             if (cmd.DueTime != null)
             {
                 clock = Domain.Clock.Create(() => cmd.DueTime.Value);
+            }
+            else
+            {
+                clock = cmd.Clock;
             }
 
             using (CommandContext.Establish(cmd.Command, clock))

--- a/Domain.Sql/CommandScheduler/Storage.cs
+++ b/Domain.Sql/CommandScheduler/Storage.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
                     AggregateType = Command.TargetNameFor(scheduledCommand.Command.GetType()),
                     SerializedCommand = scheduledCommand.ToJson(),
                     CreatedTime = domainTime,
-                    DueTime = scheduledCommand.DueTime,
+                    DueTime = scheduledCommand.DueTime ?? schedulerClock.Now(),
                     Clock = schedulerClock
                 };
 

--- a/Domain.Sql/CommandScheduler/Storage.cs
+++ b/Domain.Sql/CommandScheduler/Storage.cs
@@ -263,9 +263,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
                 }
             }
 
-            scheduledCommand.Result = new CommandScheduled(
-                scheduledCommand,
-                storedScheduledCommand.Clock);
+            scheduledCommand.Result = new CommandScheduled(scheduledCommand);
         }
     }
 }

--- a/Domain.Testing/CommandScheduler.cs
+++ b/Domain.Testing/CommandScheduler.cs
@@ -67,7 +67,9 @@ namespace Microsoft.Its.Domain.Testing
                 }
                 else if (command.Result == null)
                 {
-                    command.Result = new CommandScheduled(command);
+                    var clock = Clock.Current;
+
+                    command.Result = new CommandScheduled(command, clock);
 
                     VirtualClock.Schedule(
                         command,

--- a/Domain.Testing/CommandScheduler.cs
+++ b/Domain.Testing/CommandScheduler.cs
@@ -67,9 +67,7 @@ namespace Microsoft.Its.Domain.Testing
                 }
                 else if (command.Result == null)
                 {
-                    var clock = Clock.Current;
-
-                    command.Result = new CommandScheduled(command, clock);
+                    command.Result = new CommandScheduled(command);
 
                     VirtualClock.Schedule(
                         command,

--- a/Domain.Testing/VirtualClock.cs
+++ b/Domain.Testing/VirtualClock.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Its.Domain.Testing
             do
             {
                 var pendingCommands = commandsInPipeline
-                    .Where(c => c.Result is CommandScheduled)
+                    .Select(c => c.Result)
+                    .OfType<CommandScheduled>()
                     .ToArray();
 
                 if (pendingCommands.Any())

--- a/Domain.Testing/VirtualClock.cs
+++ b/Domain.Testing/VirtualClock.cs
@@ -91,8 +91,7 @@ namespace Microsoft.Its.Domain.Testing
             do
             {
                 var pendingCommands = commandsInPipeline
-                    .Select(c => c.Result)
-                    .OfType<CommandScheduled>()
+                    .Where(c => c.Result is CommandScheduled)
                     .ToArray();
 
                 if (pendingCommands.Any())

--- a/Domain.Tests/(Pocket)/PocketContainer.cs
+++ b/Domain.Tests/(Pocket)/PocketContainer.cs
@@ -113,7 +113,18 @@ namespace Pocket
             Func<PocketContainer, object> func;
             if (!resolvers.TryGetValue(type, out func))
             {
-                return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                try
+                {
+                    return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null   )
+                    {
+                        throw ex.InnerException;
+                    }
+                    throw;
+                }
             }
             return func(this);
         }

--- a/Domain.Tests/BloomFilterTests.cs
+++ b/Domain.Tests/BloomFilterTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Its.Log.Instrumentation;
-using Microsoft.Its.Domain.Serialization;
 using Newtonsoft.Json;
 using NUnit.Framework;
 

--- a/Domain.Tests/CommandScheduled_T_Tests.cs
+++ b/Domain.Tests/CommandScheduled_T_Tests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;
@@ -14,19 +13,21 @@ namespace Microsoft.Its.Domain.Tests
             ICommand<T> command,
             Guid aggregateId,
             DateTimeOffset? dueTime = null,
-            IPrecondition deliveryDependsOn = null)
+            IPrecondition deliveryDependsOn = null,
+            IClock clock = null)
         {
             return new CommandScheduled<T>
             {
                 Command = command,
                 AggregateId = aggregateId,
                 DueTime = dueTime,
-                DeliveryPrecondition = deliveryDependsOn
+                DeliveryPrecondition = deliveryDependsOn,
+                Clock = clock
             };
         }
 
         [Test]
-        public async Task Event_ETag_cannot_be_the_same_as_the_command_etag()
+        public void Event_ETag_cannot_be_the_same_as_the_command_etag()
         {
             var etag1 = Any.Word().ToETag();
 

--- a/Domain.Tests/CommandSchedulingTests_EventSourced.cs
+++ b/Domain.Tests/CommandSchedulingTests_EventSourced.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Its.Domain.Tests
             var it = new MarcoPoloPlayerWhoIsIt()
                 .Apply(new MarcoPoloPlayerWhoIsIt.AddPlayer { PlayerId = Any.Guid() })
                 .Apply(new MarcoPoloPlayerWhoIsIt.AddPlayer { PlayerId = Any.Guid() });
-            Console.WriteLine("[Saving]");
+
             await configuration.Repository<MarcoPoloPlayerWhoIsIt>().Save(it);
 
             var sourceEtag = Any.Guid().ToString();
@@ -313,7 +313,6 @@ namespace Microsoft.Its.Domain.Tests
                 ETag = sourceEtag
             });
             var firstPassEtags = scheduled.Select(c => c.ETag).ToArray();
-            Console.WriteLine(new { firstPassEtags }.ToLogString());
 
             scheduled.Clear();
 
@@ -324,10 +323,7 @@ namespace Microsoft.Its.Domain.Tests
                 ETag = sourceEtag
             });
 
-            Console.WriteLine("about to advance clock for the second time");
-
             var secondPassEtags = scheduled.Select(c => c.ETag).ToArray();
-            Console.WriteLine(new { secondPassEtags }.ToLogString());
 
             secondPassEtags.Should()
                            .Equal(firstPassEtags);

--- a/Domain.Tests/CommandTarget.cs
+++ b/Domain.Tests/CommandTarget.cs
@@ -142,31 +142,17 @@ namespace Microsoft.Its.Domain.Tests
 
     public class TestCommand : Command<CommandTarget>, ISpecifySchedulingBehavior
     {
-        private readonly bool isValid;
-
         public TestCommand(string etag = null, bool isValid = true) : base(etag)
         {
-            this.isValid = isValid;
+            IsValid = isValid;
 
             RequiresDurableScheduling = true;
             CanBeDeliveredDuringScheduling = true;
         }
 
-        public bool IsValid
-        {
-            get
-            {
-                return isValid;
-            }
-        }
+        public bool IsValid { get; }
 
-        public override IValidationRule CommandValidator
-        {
-            get
-            {
-                return Validate.That<TestCommand>(cmd => cmd.isValid);
-            }
-        }
+        public override IValidationRule CommandValidator => Validate.That<TestCommand>(cmd => cmd.IsValid);
 
         public bool CanBeDeliveredDuringScheduling { get; set; }
 
@@ -181,7 +167,7 @@ namespace Microsoft.Its.Domain.Tests
         {
             if (targetIds == null)
             {
-                throw new ArgumentNullException("targetIds");
+                throw new ArgumentNullException(nameof(targetIds));
             }
             if (!targetIds.Any())
             {
@@ -191,7 +177,7 @@ namespace Microsoft.Its.Domain.Tests
             TargetIds = targetIds;
         }
 
-        public string[] TargetIds { get; private set; }
+        public string[] TargetIds { get; }
     }
 
     public class RequestReply : Command<CommandTarget>

--- a/Domain.Tests/ScheduledCommand_T_Tests.cs
+++ b/Domain.Tests/ScheduledCommand_T_Tests.cs
@@ -23,12 +23,16 @@ namespace Microsoft.Its.Domain.Tests
             ICommand<T> command,
             Guid aggregateId,
             DateTimeOffset? dueTime = null,
-            IPrecondition deliveryDependsOn = null)
+            IPrecondition deliveryDependsOn = null,
+            IClock clock = null)
         {
             return new ScheduledCommand<T>(command,
                                            aggregateId,
                                            dueTime,
-                                           deliveryDependsOn);
+                                           deliveryDependsOn)
+            {
+                Clock = clock
+            };
         }
     }
 }

--- a/Domain.Tests/packages.config
+++ b/Domain.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="PocketContainer" version="1.2.6" targetFramework="net451" developmentDependency="true" />
+  <package id="PocketContainer" version="1.2.7" targetFramework="net452" developmentDependency="true" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />

--- a/Domain/(Pocket)/PocketContainer.cs
+++ b/Domain/(Pocket)/PocketContainer.cs
@@ -113,7 +113,18 @@ namespace Pocket
             Func<PocketContainer, object> func;
             if (!resolvers.TryGetValue(type, out func))
             {
-                return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                try
+                {
+                    return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null   )
+                    {
+                        throw ex.InnerException;
+                    }
+                    throw;
+                }
             }
             return func(this);
         }

--- a/Domain/AnonymousCommandHandler{TTarget,TCommand}.cs
+++ b/Domain/AnonymousCommandHandler{TTarget,TCommand}.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive;
+using System.Threading.Tasks;
+
+namespace Microsoft.Its.Domain
+{
+    internal class AnonymousCommandHandler<TTarget, TCommand> : ICommandHandler<TTarget, TCommand>
+        where TCommand : class, ICommand<TTarget>
+    {
+        private readonly HandleScheduledCommandException<TTarget, TCommand> handleScheduledCommandException;
+
+        private readonly EnactCommand<TTarget, TCommand> enactCommand;
+
+        public AnonymousCommandHandler(
+            EnactCommand<TTarget, TCommand> enactCommand,
+            HandleScheduledCommandException<TTarget, TCommand> handleScheduledCommandException = null)
+        {
+            if (enactCommand == null)
+            {
+                throw new ArgumentNullException(nameof(enactCommand));
+            }
+
+            this.enactCommand = enactCommand;
+
+            this.handleScheduledCommandException = handleScheduledCommandException ??
+                                                   ((target, command) => Task.FromResult(Unit.Default));
+        }
+
+        public Task EnactCommand(TTarget target, TCommand command) => 
+            enactCommand(target, command);
+
+        public Task HandleScheduledCommandException(
+            TTarget target,
+            CommandFailed<TCommand> command) => 
+            handleScheduledCommandException(target, command);
+    }
+}

--- a/Domain/CommandHandler{TTarget}.cs
+++ b/Domain/CommandHandler{TTarget}.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Microsoft.Its.Domain
+{
+    internal static class CommandHandler<TTarget>
+    {
+        private static readonly ConcurrentDictionary<Type, Type> interfaces = new ConcurrentDictionary<Type, Type>();
+
+        public static Type ForCommandType(Type commandType) =>
+            interfaces.GetOrAdd(commandType,
+                                t => typeof (ICommandHandler<,>).MakeGenericType(typeof (TTarget), t));
+    }
+}

--- a/Domain/ConfigurationContext.cs
+++ b/Domain/ConfigurationContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Its.Domain
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
-            this.Configuration = configuration;
+            Configuration = configuration;
         }
 
         public static ConfigurationContext Establish(Configuration configuration)

--- a/Domain/ConfigurationExtensions.cs
+++ b/Domain/ConfigurationExtensions.cs
@@ -184,6 +184,28 @@ namespace Microsoft.Its.Domain
             return configuration;
         }
 
+        /// <summary>
+        /// Registers a command handler for the specified command type.
+        /// </summary>
+        /// <typeparam name="TTarget">The type of the command target.</typeparam>
+        /// <typeparam name="TCommand">The type of the command.</typeparam>
+        /// <param name="configuration">The configuration.</param>
+        /// <param name="enactCommand">A delegate to enact the command when it has passed authorization and validation checks.</param>
+        /// <param name="handleScheduledCommandException">A delegate to handle errors that occur when a scheduled command is delivered.</param>
+        public static Configuration UseCommandHandler<TTarget, TCommand>(
+            this Configuration configuration,
+            EnactCommand<TTarget, TCommand> enactCommand,
+            HandleScheduledCommandException<TTarget, TCommand> handleScheduledCommandException = null)
+            where TCommand : class, ICommand<TTarget>
+        {
+            configuration.Container
+                         .Register<ICommandHandler<TTarget, TCommand>>(
+                             c =>
+                             new AnonymousCommandHandler<TTarget, TCommand>(enactCommand, handleScheduledCommandException));
+
+            return configuration;
+        }
+
         public static ISnapshotRepository SnapshotRepository(this Configuration configuration) =>
             configuration.Container.Resolve<ISnapshotRepository>();
 

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Annotate.cs" />
     <Compile Include="Annotated.cs" />
     <Compile Include="AnonymousClock.cs" />
+    <Compile Include="AnonymousCommandHandler{TTarget,TCommand}.cs" />
     <Compile Include="Authorization\AuthorizationExtensions.cs" />
     <Compile Include="Authorization\AuthorizationPolicy.cs" />
     <Compile Include="Authorization\AuthorizationQuery.cs" />
@@ -102,11 +103,13 @@
     <Compile Include="CommandContext.cs" />
     <Compile Include="CommandExtensions.cs" />
     <Compile Include="CommandHandler.cs" />
+    <Compile Include="CommandHandler{TTarget}.cs" />
     <Compile Include="CommandReference.cs" />
     <Compile Include="CommandSchedulerPipelineTraceInitializer.cs" />
     <Compile Include="ConfigurationContext.cs" />
     <Compile Include="ConfigurationExtensions.cs" />
     <Compile Include="DomainConfigurationException.cs" />
+    <Compile Include="EnactCommand{TTarget,TCommand}.cs" />
     <Compile Include="EventHandling\AnonymousConsequenter{TEvent}.cs" />
     <Compile Include="EventHandling\AnonymousProjector{TEvent}.cs" />
     <Compile Include="EventHandling\CompositeEventHandler.cs" />
@@ -128,6 +131,7 @@
     <Compile Include="EventNameAttribute.cs" />
     <Compile Include="EventMigrations.cs" />
     <Compile Include="Convert.cs" />
+    <Compile Include="HandleScheduledCommandException{TTarget,TCommand}.cs" />
     <Compile Include="Hash.cs" />
     <Compile Include="IClock.cs" />
     <Compile Include="EventHandling\Projector.cs" />

--- a/Domain/EnactCommand{TTarget,TCommand}.cs
+++ b/Domain/EnactCommand{TTarget,TCommand}.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Its.Domain
+{
+    public delegate Task EnactCommand<in TTarget, in TCommand>(TTarget target, TCommand command)
+        where TCommand : class, ICommand<TTarget>;
+}

--- a/Domain/HandleScheduledCommandException{TTarget,TCommand}.cs
+++ b/Domain/HandleScheduledCommandException{TTarget,TCommand}.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Its.Domain
+{
+    public delegate Task HandleScheduledCommandException<in TTarget, TCommand>(TTarget target, CommandFailed<TCommand> command)
+        where TCommand : class, ICommand<TTarget>;
+}

--- a/Domain/Scheduling/CommandScheduled.cs
+++ b/Domain/Scheduling/CommandScheduled.cs
@@ -11,11 +11,14 @@ namespace Microsoft.Its.Domain
     [DebuggerDisplay("{ToString()}")]
     public class CommandScheduled : ScheduledCommandResult
     {
-        public CommandScheduled(IScheduledCommand command) : base(command)
+        public CommandScheduled(IScheduledCommand command, IClock clock = null) : base(command)
         {
+            Clock = clock;
         }
 
+        public IClock Clock { get; }
+
         public override string ToString() =>
-            $"Scheduled{ScheduledCommand.Clock.IfNotNull().Then(c => " on clock " + c).ElseDefault()}";
+            $"Scheduled{Clock.IfNotNull().Then(c => " on clock " + c).ElseDefault()}";
     }
 }

--- a/Domain/Scheduling/CommandScheduled.cs
+++ b/Domain/Scheduling/CommandScheduled.cs
@@ -11,14 +11,11 @@ namespace Microsoft.Its.Domain
     [DebuggerDisplay("{ToString()}")]
     public class CommandScheduled : ScheduledCommandResult
     {
-        public CommandScheduled(IScheduledCommand command, IClock clock = null) : base(command)
+        public CommandScheduled(IScheduledCommand command) : base(command)
         {
-            Clock = clock;
         }
 
-        public IClock Clock { get; }
-
         public override string ToString() =>
-            $"Scheduled{Clock.IfNotNull().Then(c => " on clock " + c).ElseDefault()}";
+            $"Scheduled{ScheduledCommand.Clock.IfNotNull().Then(c => " on clock " + c).ElseDefault()}";
     }
 }

--- a/Domain/Scheduling/CommandScheduled{T}.cs
+++ b/Domain/Scheduling/CommandScheduled{T}.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Its.Domain
     {
         private ScheduledCommandResult result;
         private ICommand<TAggregate> command;
-        private IClock clock;
 
         public CommandScheduled()
         {
@@ -91,17 +90,7 @@ namespace Microsoft.Its.Domain
         /// Gets the clock on which the command is scheduled.
         /// </summary>
         [JsonIgnore]
-        public IClock Clock
-        {
-            get
-            {
-                return clock ?? (clock = Domain.Clock.Current);
-            }
-            set
-            {
-                clock = value;
-            }
-        }
+        public IClock Clock { get; set; }
 
         /// <summary>
         /// Updates an aggregate to a new state.

--- a/Domain/Scheduling/CommandScheduled{T}.cs
+++ b/Domain/Scheduling/CommandScheduled{T}.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Its.Domain
     {
         private ScheduledCommandResult result;
         private ICommand<TAggregate> command;
+        private IClock clock;
 
         public CommandScheduled()
         {
@@ -90,7 +91,17 @@ namespace Microsoft.Its.Domain
         /// Gets the clock on which the command is scheduled.
         /// </summary>
         [JsonIgnore]
-        public IClock Clock { get; set; }
+        public IClock Clock
+        {
+            get
+            {
+                return clock ?? (clock = Domain.Clock.Current);
+            }
+            set
+            {
+                clock = value;
+            }
+        }
 
         /// <summary>
         /// Updates an aggregate to a new state.

--- a/Domain/Scheduling/IScheduledCommand.cs
+++ b/Domain/Scheduling/IScheduledCommand.cs
@@ -23,11 +23,19 @@ namespace Microsoft.Its.Domain
         [JsonConverter(typeof (PreconditionConverter))]
         IPrecondition DeliveryPrecondition { get; }
 
+        /// <summary>
+        /// Gets or sets the result of the scheduled command after the command scheduler has attempted to schedule or deliver it.
+        /// </summary>
         ScheduledCommandResult Result { get; set; }
 
         /// <summary>
         /// Gets the number of times the scheduler has previously attempted to deliver the command.
         /// </summary>
         int NumberOfPreviousAttempts { get; }
+
+        /// <summary>
+        /// Gets the clock on which the command is scheduled.
+        /// </summary>
+        IClock Clock { get; }
     }
 }

--- a/Domain/Scheduling/IScheduledCommand.cs
+++ b/Domain/Scheduling/IScheduledCommand.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Its.Domain
         /// <summary>
         /// Gets the clock on which the command is scheduled.
         /// </summary>
-        IClock Clock { get; }
+        IClock Clock { get; set; }
     }
 }

--- a/Domain/Scheduling/IScheduledCommand.cs
+++ b/Domain/Scheduling/IScheduledCommand.cs
@@ -36,6 +36,6 @@ namespace Microsoft.Its.Domain
         /// <summary>
         /// Gets the clock on which the command is scheduled.
         /// </summary>
-        IClock Clock { get; set; }
+        IClock Clock { get; }
     }
 }

--- a/Domain/Scheduling/ScheduledCommandExtensions.cs
+++ b/Domain/Scheduling/ScheduledCommandExtensions.cs
@@ -20,6 +20,10 @@ namespace Microsoft.Its.Domain
 
             clock = clock ??
                     command.Clock ??
+                    command.Result
+                           .IfTypeIs<CommandScheduled>()
+                           .Then(scheduled => scheduled.Clock)
+                           .ElseDefault() ??
                     Clock.Current;
 
             return (command.DueTime == null ||

--- a/Domain/Scheduling/ScheduledCommandExtensions.cs
+++ b/Domain/Scheduling/ScheduledCommandExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Its.Domain
             }
 
             clock = clock ??
+                    command.Clock ??
                     command.Result
                            .IfTypeIs<CommandScheduled>()
                            .Then(scheduled => scheduled.Clock)

--- a/Domain/Scheduling/ScheduledCommandExtensions.cs
+++ b/Domain/Scheduling/ScheduledCommandExtensions.cs
@@ -20,10 +20,6 @@ namespace Microsoft.Its.Domain
 
             clock = clock ??
                     command.Clock ??
-                    command.Result
-                           .IfTypeIs<CommandScheduled>()
-                           .Then(scheduled => scheduled.Clock)
-                           .ElseDefault() ??
                     Clock.Current;
 
             return (command.DueTime == null ||

--- a/Domain/Scheduling/ScheduledCommand{T}.cs
+++ b/Domain/Scheduling/ScheduledCommand{T}.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Its.Domain
         private static readonly bool targetIsEventSourced;
         internal static readonly Func<IScheduledCommand<TTarget>, Guid> TargetGuid;
         private ScheduledCommandResult result;
+        private IClock clock;
 
         static ScheduledCommand()
         {
@@ -86,7 +87,17 @@ namespace Microsoft.Its.Domain
         /// Gets the clock on which the command is scheduled.
         /// </summary>
         [JsonIgnore]
-        public IClock Clock { get; set; }
+        public IClock Clock
+        {
+            get
+            {
+                return clock ?? (clock = Domain.Clock.Current);
+            }
+            set
+            {
+                clock = value;
+            }
+        }
 
         /// <summary>
         /// Gets the command to be applied at a later time.

--- a/Domain/Scheduling/ScheduledCommand{T}.cs
+++ b/Domain/Scheduling/ScheduledCommand{T}.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Its.Domain
         private static readonly bool targetIsEventSourced;
         internal static readonly Func<IScheduledCommand<TTarget>, Guid> TargetGuid;
         private ScheduledCommandResult result;
-        private IClock clock;
 
         static ScheduledCommand()
         {
@@ -87,17 +86,7 @@ namespace Microsoft.Its.Domain
         /// Gets the clock on which the command is scheduled.
         /// </summary>
         [JsonIgnore]
-        public IClock Clock
-        {
-            get
-            {
-                return clock ?? (clock = Domain.Clock.Current);
-            }
-            set
-            {
-                clock = value;
-            }
-        }
+        public IClock Clock { get; set; }
 
         /// <summary>
         /// Gets the command to be applied at a later time.

--- a/Domain/Scheduling/ScheduledCommand{T}.cs
+++ b/Domain/Scheduling/ScheduledCommand{T}.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Its.Domain
         [JsonConverter(typeof (CommandConverter))]
         public ICommand<TTarget> Command { get; }
         
+        [JsonIgnore]
         public int NumberOfPreviousAttempts { get; set; }
 
         /// <summary>
@@ -143,8 +144,10 @@ namespace Microsoft.Its.Domain
         /// </returns>
         public override string ToString()
         {
-            return string.Format("{0}{1}{2}{3}",
+            return string.Format("{0} ({1} .. {2}) {3}{4}{5}",
                                  Command,
+                                 TargetId,
+                                 Command.ETag,
                                  DueTime.IfNotNull()
                                         .Then(due => " due " + due)
                                         .ElseDefault(),

--- a/Domain/Scheduling/ScheduledCommand{T}.cs
+++ b/Domain/Scheduling/ScheduledCommand{T}.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Its.Domain
         private static readonly bool targetIsEventSourced;
         internal static readonly Func<IScheduledCommand<TTarget>, Guid> TargetGuid;
         private ScheduledCommandResult result;
+        private IClock clock;
 
         static ScheduledCommand()
         {
@@ -83,11 +84,30 @@ namespace Microsoft.Its.Domain
         }
 
         /// <summary>
+        /// Gets the clock on which the command is scheduled.
+        /// </summary>
+        [JsonIgnore]
+        public IClock Clock
+        {
+            get
+            {
+                return clock ?? (clock = Domain.Clock.Current);
+            }
+            set
+            {
+                clock = value;
+            }
+        }
+
+        /// <summary>
         /// Gets the command to be applied at a later time.
         /// </summary>
         [JsonConverter(typeof (CommandConverter))]
         public ICommand<TTarget> Command { get; }
-        
+
+        /// <summary>
+        /// Gets the number of times the scheduler has previously attempted to deliver the command.
+        /// </summary>
         [JsonIgnore]
         public int NumberOfPreviousAttempts { get; set; }
 
@@ -96,6 +116,9 @@ namespace Microsoft.Its.Domain
         /// </summary>
         public string TargetId { get; }
 
+        /// <summary>
+        /// Gets the aggregate identifier, if command target is event sourced.
+        /// </summary>
         public Guid? AggregateId =>
             targetIsEventSourced
                 ? (Guid?) Guid.Parse(TargetId)
@@ -112,7 +135,7 @@ namespace Microsoft.Its.Domain
         /// <remarks>
         /// If this to is null, the command should be delivered as soon as possible.
         /// </remarks>
-        public DateTimeOffset? DueTime { get; }
+        public DateTimeOffset? DueTime { get; set; }
 
         /// <summary>
         /// Indicates a precondition ETag for a specific aggregate. If no event on the target aggregate exists with this ETag, the command will fail, and the aggregate can decide whether to reschedule or ignore the command.
@@ -143,21 +166,18 @@ namespace Microsoft.Its.Domain
         /// A <see cref="System.String" /> that represents this instance.
         /// </returns>
         public override string ToString()
-        {
-            return string.Format("{0} ({1} .. {2}) {3}{4}{5}",
-                                 Command,
-                                 TargetId,
-                                 Command.ETag,
-                                 DueTime.IfNotNull()
-                                        .Then(due => " due " + due)
-                                        .ElseDefault(),
-                                 DeliveryPrecondition.IfNotNull()
-                                                     .Then(p => ", depends on " + p)
-                                                     .ElseDefault(),
-                                 Result.IfNotNull()
-                                       .Then(r => ", " + r)
-                                       .ElseDefault());
-        }
-
+            => string.Format("{0} ({1} .. {2}) {3}{4}{5}",
+                             Command,
+                             TargetId,
+                             Command.ETag,
+                             DueTime.IfNotNull()
+                                    .Then(due => " due " + due)
+                                    .ElseDefault(),
+                             DeliveryPrecondition.IfNotNull()
+                                                 .Then(p => ", depends on " + p)
+                                                 .ElseDefault(),
+                             Result.IfNotNull()
+                                   .Then(r => ", " + r)
+                                   .ElseDefault());
     }
 }

--- a/Domain/packages.config
+++ b/Domain/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Its.Validation" version="1.4.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="PocketContainer" version="1.2.6" targetFramework="net451" developmentDependency="true" />
+  <package id="PocketContainer" version="1.2.7" targetFramework="net452" developmentDependency="true" />
   <package id="PocketContainer.Clone" version="1.0.4" targetFramework="net451" developmentDependency="true" />
   <package id="PocketContainer.OpenGenericStrategy" version="1.0.3" targetFramework="net451" developmentDependency="true" />
   <package id="PocketContainer.PrimitiveAvoidanceStrategy" version="1.0.3" targetFramework="net451" developmentDependency="true" />

--- a/Recipes/ServiceBus/ServiceBusCommandQueueReceiver.cs
+++ b/Recipes/ServiceBus/ServiceBusCommandQueueReceiver.cs
@@ -250,9 +250,9 @@ namespace Microsoft.Its.Domain.ServiceBus
             private int NumberOfPreviousAttempts { get; set; }
 
             [JsonIgnore]
-            IClock IScheduledCommand.Clock { get; }
+            IClock IScheduledCommand.Clock { get; set; }
 
-            int IScheduledCommand.NumberOfPreviousAttempts => this.NumberOfPreviousAttempts;
+            int IScheduledCommand.NumberOfPreviousAttempts => NumberOfPreviousAttempts;
 
             public BrokeredMessage BrokeredMessage { get; internal set; }
         }

--- a/Recipes/ServiceBus/ServiceBusCommandQueueReceiver.cs
+++ b/Recipes/ServiceBus/ServiceBusCommandQueueReceiver.cs
@@ -250,9 +250,9 @@ namespace Microsoft.Its.Domain.ServiceBus
             private int NumberOfPreviousAttempts { get; set; }
 
             [JsonIgnore]
-            IClock IScheduledCommand.Clock { get; set; }
+            IClock IScheduledCommand.Clock { get; }
 
-            int IScheduledCommand.NumberOfPreviousAttempts => NumberOfPreviousAttempts;
+            int IScheduledCommand.NumberOfPreviousAttempts => this.NumberOfPreviousAttempts;
 
             public BrokeredMessage BrokeredMessage { get; internal set; }
         }

--- a/Recipes/ServiceBus/ServiceBusCommandQueueReceiver.cs
+++ b/Recipes/ServiceBus/ServiceBusCommandQueueReceiver.cs
@@ -242,26 +242,17 @@ namespace Microsoft.Its.Domain.ServiceBus
 
             public EventHasBeenRecordedPrecondition DeliveryPrecondition { get; set; }
 
-            IPrecondition IScheduledCommand.DeliveryPrecondition
-            {
-                get
-                {
-                    return DeliveryPrecondition;
-                }
-            }
+            IPrecondition IScheduledCommand.DeliveryPrecondition => DeliveryPrecondition;
 
             [JsonIgnore]
             public ScheduledCommandResult Result { get; set; }
 
             private int NumberOfPreviousAttempts { get; set; }
 
-            int IScheduledCommand.NumberOfPreviousAttempts
-            {
-                get
-                {
-                    return this.NumberOfPreviousAttempts;
-                }
-            }
+            [JsonIgnore]
+            IClock IScheduledCommand.Clock { get; }
+
+            int IScheduledCommand.NumberOfPreviousAttempts => this.NumberOfPreviousAttempts;
 
             public BrokeredMessage BrokeredMessage { get; internal set; }
         }

--- a/Sample.Domain.Api/(Pocket)/PocketContainer.cs
+++ b/Sample.Domain.Api/(Pocket)/PocketContainer.cs
@@ -113,7 +113,18 @@ namespace Pocket
             Func<PocketContainer, object> func;
             if (!resolvers.TryGetValue(type, out func))
             {
-                return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                try
+                {
+                    return resolveMethod.MakeGenericMethod(type).Invoke(this, null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null   )
+                    {
+                        throw ex.InnerException;
+                    }
+                    throw;
+                }
             }
             return func(this);
         }

--- a/Sample.Domain.Api/packages.config
+++ b/Sample.Domain.Api/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="Modernizr" version="2.5.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="PocketContainer" version="1.2.6" targetFramework="net451" developmentDependency="true" />
+  <package id="PocketContainer" version="1.2.7" targetFramework="net452" developmentDependency="true" />
   <package id="PocketContainer.WebApiDependencyResolver" version="1.0.6" targetFramework="net451" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/Sample.Domain/CustomerAccount/Commands/RequestUserName.cs
+++ b/Sample.Domain/CustomerAccount/Commands/RequestUserName.cs
@@ -27,7 +27,7 @@ namespace Sample.Domain
                                                 .Identity
                                                 .Name).Result)
                                        .WithErrorMessage(
-                                           (f, c) => string.Format("The user name {0} is taken. Please choose another.", c.UserName));
+                                           (f, c) => $"The user name {c.UserName} is taken. Please choose another.");
 
                 return new ValidationPlan<RequestUserName>
                        {
@@ -37,20 +37,8 @@ namespace Sample.Domain
             }
         }
 
-        public bool RequiresDurableScheduling
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public bool RequiresDurableScheduling => false;
 
-        public bool CanBeDeliveredDuringScheduling
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool CanBeDeliveredDuringScheduling => true;
     }
 }

--- a/Sample.Domain/Ordering/Commands/CreateOrder.cs
+++ b/Sample.Domain/Ordering/Commands/CreateOrder.cs
@@ -10,7 +10,7 @@ using Its.Validation.Configuration;
 namespace Sample.Domain.Ordering.Commands
 {
     [DebuggerStepThrough]
-    public class CreateOrder : ConstructorCommand<Order>
+    public class CreateOrder : ConstructorCommand<Order>, ISpecifySchedulingBehavior
     {
         public CreateOrder(string customerName, string etag = null) : base(etag)
         {
@@ -30,5 +30,9 @@ namespace Sample.Domain.Ordering.Commands
                                .WithErrorMessage("You must provide a customer name");
             }
         }
+
+        public bool CanBeDeliveredDuringScheduling { get; set; } = true;
+
+        public bool RequiresDurableScheduling { get; set; } = true;
     }
 }


### PR DESCRIPTION
This addresses issue #124. Along the way, it introduces `IScheduledCommand.Clock` and paves the way to setting clock affinities at the command level.