### PR TITLE
Object id serialization fix

### DIFF
--- a/Domain.Sql.Tests/DatabaseSetupAndMigrationTests.cs
+++ b/Domain.Sql.Tests/DatabaseSetupAndMigrationTests.cs
@@ -15,11 +15,13 @@ using Microsoft.Its.Domain.Sql.Migrations;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;
 using System.Data.SqlClient;
+using NCrunch.Framework;
 using Sample.Domain.Projections;
 
 namespace Microsoft.Its.Domain.Sql.Tests
 {
     [TestFixture]
+    [ExclusivelyUses("ItsCqrsMigrationsTestCommandScheduler","ItsCqrsMigrationsTestEventStore","ItsCqrsMigrationsTestReadModels")]
     public class DatabaseSetupAndMigrationTests
     {
         private const string CommandSchedulerConnectionString =

--- a/Domain.Sql.Tests/Domain.Sql.Tests.csproj
+++ b/Domain.Sql.Tests/Domain.Sql.Tests.csproj
@@ -76,6 +76,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="NCrunch.Framework, Version=2.20.0.4, Culture=neutral, PublicKeyToken=01d101bf6f3e0aea, processorArchitecture=MSIL">
+      <HintPath>..\packages\NCrunch.Framework.2.20.0.4\lib\portable-windows8+net45\NCrunch.Framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Domain.Sql.Tests/EventStoreDbTest.cs
+++ b/Domain.Sql.Tests/EventStoreDbTest.cs
@@ -9,13 +9,15 @@ using System.Threading.Tasks;
 using Microsoft.Its.Domain.Sql.CommandScheduler;
 using Microsoft.Its.Domain.Tests.Infrastructure;
 using Microsoft.Its.Recipes;
+using NCrunch.Framework;
 using NUnit.Framework;
 using Sample.Domain;
 using Sample.Domain.Ordering;
 
 namespace Microsoft.Its.Domain.Sql.Tests
 {
-    public class EventStoreDbTest 
+    [ExclusivelyUses("ItsCqrsTestsEventStore", "ItsCqrsTestsReadModels", "ItsCqrsTestsCommandScheduler")]
+    public class EventStoreDbTest
     {
         private static bool databasesInitialized;
         private static readonly object lockObj = new object();

--- a/Domain.Sql.Tests/ReadModelCatchupRollingCatchupTests.cs
+++ b/Domain.Sql.Tests/ReadModelCatchupRollingCatchupTests.cs
@@ -29,13 +29,7 @@ namespace Microsoft.Its.Domain.Sql.Tests
 {
     [Category("Catchups")]
     [TestFixture]
-    public  class ReadModelRollingCatchupTests : RollingCatchupTest
-    {
-    }
-
-    [Category("Catchups")]
-    [TestFixture]
-    public abstract class RollingCatchupTest : EventStoreDbTest
+    public class RollingCatchupTest : EventStoreDbTest
     {
         [Test]
         public void Events_committed_to_the_event_store_are_caught_up_by_multiple_independent_read_model_stores()

--- a/Domain.Sql.Tests/ReadModelCatchupTests.cs
+++ b/Domain.Sql.Tests/ReadModelCatchupTests.cs
@@ -22,14 +22,9 @@ using Its.Log.Instrumentation;
 
 namespace Microsoft.Its.Domain.Sql.Tests
 {
-    [TestFixture]
-    public  class ReadModelCatchupTests : ReadModelCatchupTest
-    {
-    }
-
     [Category("Catchups")]
     [TestFixture]
-    public abstract class ReadModelCatchupTest : EventStoreDbTest
+    public class ReadModelCatchupTest : EventStoreDbTest
     {
         private readonly TimeSpan MaxWaitTime = TimeSpan.FromSeconds(5);
 

--- a/Domain.Sql.Tests/packages.config
+++ b/Domain.Sql.Tests/packages.config
@@ -6,6 +6,7 @@
   <package id="Its.Log" version="2.9.13" targetFramework="net452" />
   <package id="Its.Validation" version="1.4.3" targetFramework="net451" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="NCrunch.Framework" version="2.20.0.4" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
   <package id="PocketContainer" version="1.2.7" targetFramework="net452" developmentDependency="true" />

--- a/Domain.Tests/ConfigurationTests.cs
+++ b/Domain.Tests/ConfigurationTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.Its.Domain.Sql;
+using Microsoft.Its.Domain.Testing;
 using Microsoft.Its.Recipes;
 using Moq;
 using NUnit.Framework;
@@ -51,7 +52,7 @@ namespace Microsoft.Its.Domain.Tests
             container.Register(c => "hello");
 
             var configuration = new Configuration()
-                .UseSqlEventStore()
+                .UseInMemoryEventStore()
                 .UseDependency(resolve: resolve => (IEventBus) resolve(typeof (EventBusWithDependencies)))
                 .UseDependency<IEnumerable<string>>(_ => new[] { "hello" });
 

--- a/Domain.Tests/ObjectIdTests.cs
+++ b/Domain.Tests/ObjectIdTests.cs
@@ -19,20 +19,20 @@ namespace Microsoft.Its.Domain.Tests
         {
             var obj = new Widget
             {
-                Id = 123
+                IdOfInt = 123
             };
 
             var json = obj.ToJson();
 
             var obj2 = json.FromJsonTo<Widget>();
 
-            obj2.Id.Value.Should().Be(123);
+            obj2.IdOfInt.Value.Should().Be(123);
         }
 
         [Test]
         public void Value_cannot_be_set_to_default()
         {
-            Assert.Throws<ArgumentException>(() => new WidgetId(0));
+            Assert.Throws<ArgumentException>(() => new ObjectIdOfInt(0));
             Assert.Throws<ArgumentException>(() => new GenericObjectId<Guid>(Guid.Empty));
         }
 
@@ -54,8 +54,8 @@ namespace Microsoft.Its.Domain.Tests
         public void Two_instances_of_type_derived_from_ObjectId_having_the_same_underlying_value_are_equal()
         {
             var id = Any.Int();
-            var id1 = new WidgetId(id);
-            var id2 = new WidgetId(id);
+            var id1 = new ObjectIdOfInt(id);
+            var id2 = new ObjectIdOfInt(id);
 
             (id1 == id2).Should().BeTrue();
             (id2 == id1).Should().BeTrue();
@@ -81,7 +81,7 @@ namespace Microsoft.Its.Domain.Tests
         public void An_instance_of_a_type_derived_from_ObjectId_is_equal_to_a_primitive_of_its_underlying_value()
         {
             var i = Any.Int();
-            var objectId = new WidgetId(i);
+            var objectId = new ObjectIdOfInt(i);
 
             (objectId == i).Should().BeTrue();
             // (i == objectId).Should().BeTrue();
@@ -117,7 +117,7 @@ namespace Microsoft.Its.Domain.Tests
         }
 
         [Test]
-        public void ObjectId_of_String_derived_classes_deserialize_from_JSON_primitives()
+        public void ObjectId_of_String_deserialize_from_a_JSON_primitive()
         {
             var json = "\"hello\"";
 
@@ -127,13 +127,45 @@ namespace Microsoft.Its.Domain.Tests
         }
 
         [Test]
-        public void ObjectId_of_String_derived_classes_deserialize_from_JSON_objects()
+        public void ObjectId_of_String_deserialize_from_a_JSON_object()
         {
             var json = "{\"Value\":\"hello\"}";
 
             var s = JsonConvert.DeserializeObject<GenericObjectId<string>>(json);
 
             s.Value.Should().Be("hello");
+        }
+
+        [Test]
+        public void ObjectId_of_Guid_serializes_to_a_JSON_primitive()
+        {
+            var guid = Any.Guid();
+
+            var json = JsonConvert.SerializeObject(new ObjectIdOfGuid(guid));
+
+            json.Should().Be("\"" + guid + "\"");
+        }
+
+        [Test]
+        public void ObjectId_of_Guid_deserialize_from_a_JSON_primitive()
+        {
+            var guid = Any.Guid();
+            var json = guid.ToJson();
+
+            var s = JsonConvert.DeserializeObject<ObjectIdOfGuid>(json);
+
+            s.Value.Should().Be(guid);
+        }
+
+        [Test]
+        public void ObjectId_of_Guid_deserializes_from_a_JSON_object()
+        {
+            var guid = Any.Guid();
+            var json = $"{{\"Value\":\"{guid}\"}}";
+
+            var s = JsonConvert.DeserializeObject<ObjectIdOfGuid>(json);
+
+            s.Value.Should().Be(guid);
         }
 
         [Test]
@@ -145,7 +177,7 @@ namespace Microsoft.Its.Domain.Tests
         }
 
         [Test]
-        public void ObjectId_of_int_derived_classes_deserialize_from_JSON_primitives()
+        public void ObjectId_of_int_deserialize_from_a_JSON_primitive()
         {
             var json = "1";
 
@@ -155,7 +187,7 @@ namespace Microsoft.Its.Domain.Tests
         }
 
         [Test]
-        public void ObjectId_of_int_derived_classes_deserialize_from_JSON_objects()
+        public void ObjectId_of_int_deserializes_from_a_JSON_object()
         {
             var json = "{\"Value\":1}";
 
@@ -163,7 +195,7 @@ namespace Microsoft.Its.Domain.Tests
 
             s.Value.Should().Be(1);
         }
-
+        
         [Test]
         public void ObjectId_of_int_correctly_serializes_to_null()
         {
@@ -173,19 +205,19 @@ namespace Microsoft.Its.Domain.Tests
         }
 
         [Test]
-        public void ObjectId_of_int_correctly_deserialized_from_null()
+        public void ObjectId_of_int_correctly_deserializes_from_null()
         {
             var json = "{\"Id\":null}";
 
             var s = JsonConvert.DeserializeObject<Widget>(json);
 
-            s.Id.Should().Be(null);
+            s.IdOfInt.Should().Be(null);
         }
     }
 
     public class Widget
     {
-        public WidgetId Id { get; set; }
+        public ObjectIdOfInt IdOfInt { get; set; }
     }
 
     public class GenericObjectId<T> : ObjectId<T>
@@ -195,15 +227,27 @@ namespace Microsoft.Its.Domain.Tests
         }
     }
 
-    public class WidgetId : ObjectId<int>
+    public class ObjectIdOfGuid : ObjectId<Guid>
     {
-        public WidgetId(int value) : base(value)
+        public ObjectIdOfGuid(Guid value) : base(value)
         {
         }
 
-        public static implicit operator WidgetId(int value)
+        public static implicit operator ObjectIdOfGuid(Guid value)
         {
-            return new WidgetId(value);
+            return new ObjectIdOfGuid(value);
+        }
+    }
+
+    public class ObjectIdOfInt : ObjectId<int>
+    {
+        public ObjectIdOfInt(int value) : base(value)
+        {
+        }
+
+        public static implicit operator ObjectIdOfInt(int value)
+        {
+            return new ObjectIdOfInt(value);
         }
     }
 }

--- a/Domain/Serialization/PrimitiveConverter.cs
+++ b/Domain/Serialization/PrimitiveConverter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Its.Domain.Serialization
                                     .Single()
                                     .ParameterType;
 
-            var getValue = typeof (PrimitiveConverter).GetMethod("GetValue",BindingFlags.NonPublic | BindingFlags.Static)
+            var getValue = typeof (PrimitiveConverter).GetMethod("GetValue", BindingFlags.NonPublic | BindingFlags.Static)
                                                       .MakeGenericMethod(ctorParamType);
             var call = Expression.Call(getValue,jt);
             var invokeCtor = Expression.New(ctor,call);
@@ -51,8 +51,8 @@ namespace Microsoft.Its.Domain.Serialization
 
         private static T GetValue<T>(JToken jToken) =>
             jToken.Type == JTokenType.Object
-                ? jToken.Value<T>("Value")
-                : jToken.Value<T>();
+                ? jToken["Value"].ToObject<T>()
+                : jToken.ToObject<T>();
 
         public override bool CanConvert(Type objectType) => true;
     }


### PR DESCRIPTION
NewtonSoft.Json configuration to simplify `ObjectId<T>`'s serialized form was throwing when deserializing `ObjectId<Guid>`. This fixes it.