### PR TITLE
Fix Azure DB compatibility issues

### DIFF
--- a/Domain.Sql/CommandScheduler/Storage.cs
+++ b/Domain.Sql/CommandScheduler/Storage.cs
@@ -234,11 +234,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
             {
                 try
                 {
-                    using (var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
-                    {
-                        await db.SaveChangesAsync();
-                        transaction.Complete();
-                    }
+                    await db.SaveChangesAsync();
                     break;
                 }
                 catch (DbUpdateException exception)

--- a/Domain.Sql/DatabaseExtensions.cs
+++ b/Domain.Sql/DatabaseExtensions.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Its.Domain.Sql
         /// <param name="dbSizeInGB">Size of database in GB</param>
         /// <param name="edition">Edition of database</param>
         /// <param name="serviceObjective">Service objective of database</param>
+        /// <param name="connectionString">Optional connection string to use instead of taking it off of <paramref name="context"/></param>
         /// <exception cref="System.ArgumentException">Not Azure database based on ConnectionString</exception>
         /// <remarks>
         /// See https://msdn.microsoft.com/en-us/library/dn268335.aspx for more info.
@@ -135,14 +136,15 @@ namespace Microsoft.Its.Domain.Sql
             this DbContext context, 
             int dbSizeInGB = 2, 
             string edition = "standard", 
-            string serviceObjective = "S0")
+            string serviceObjective = "S0",
+            string connectionString = null)
         {
             if (!context.IsAzureDatabase())
             {
                 throw new ArgumentException("Not Azure database based on ConnectionString");
             }
 
-            var connstrBldr = new SqlConnectionStringBuilder(context.Database.Connection.ConnectionString)
+            var connstrBldr = new SqlConnectionStringBuilder(connectionString ?? context.Database.Connection.ConnectionString)
             {
                 InitialCatalog = "master"
             };

--- a/Domain.Sql/Migrations/Migrator.cs
+++ b/Domain.Sql/Migrations/Migrator.cs
@@ -99,7 +99,6 @@ FROM sys.tables;";
                 return;
             }
 
-            using (var transaction = new TransactionScope())
             using (var appLock = new AppLock(context, "PocketMigrator", false))
             {
                 if (!appLock.IsAcquired)
@@ -122,7 +121,6 @@ FROM sys.tables;";
                                                         .Else(() => true))
                              .ForEach(migrator => ApplyMigration(migrator, connection));
 
-                    transaction.Complete();
                 }
                 catch (SqlException exception)
                 {


### PR DESCRIPTION
Databases could not be created due to the password not being on the connection string, and also TransactionScopes were used. See commits for more details.