### PR TITLE
Fix AzureSqlDbMigrator to use the correct database string in SQL statement

### DIFF
--- a/Domain.Sql/Migrations/AzureSqlDbMigrator.cs
+++ b/Domain.Sql/Migrations/AzureSqlDbMigrator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Its.Domain.Sql.Migrations
 
             var sql =
                 $@"
-alter database {context.Database} 
+alter database {context.Database.Connection.Database} 
 modify (MAXSIZE = {MaxSize},
         EDITION = '{Edition}',
         SERVICE_OBJECTIVE = '{ServiceObjective}')";


### PR DESCRIPTION
After the DbContext changes, this was not updated correctly to use the correct database string.