### PR TITLE
Fix NextETag regression

### DIFF
--- a/AssemblyVersion.cs
+++ b/AssemblyVersion.cs
@@ -9,4 +9,4 @@ using System.Reflection;
 [assembly: CLSCompliant(true)]
 
 // Edit these for each release + update dependencies in .nuspec files
-[assembly: AssemblyInformationalVersion("0.15.9-beta")]
+[assembly: AssemblyInformationalVersion("0.15.10-beta")]

--- a/Domain.Api/Domain.Api.nuspec
+++ b/Domain.Api/Domain.Api.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>webapi DDD CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.15.9-beta,1)" />
+      <dependency id="Its.Domain" version="[0.15.10-beta,1)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)"  />
       <dependency id="Rx-Main" version="[2.2.5,)"   />
     </dependencies>

--- a/Domain.Sql/Domain.Sql.nuspec
+++ b/Domain.Sql/Domain.Sql.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>SQL CQRS Its.Cqrs event-sourcing</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.15.9-beta,1)" />
+      <dependency id="Its.Domain" version="[0.15.10-beta,1)" />
       <dependency id="EntityFramework" version="[6.1.3,)" />
       <dependency id="Its.Validation" version="[1.1.5,2.0)" />
     </dependencies>

--- a/Domain.Testing/Domain.Testing.nuspec
+++ b/Domain.Testing/Domain.Testing.nuspec
@@ -11,8 +11,8 @@
     <copyright>Copyright 2016</copyright>
     <tags>testing CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.15.9-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.15.9-beta,1)" />
+      <dependency id="Its.Domain" version="[0.15.10-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.15.10-beta,1)" />
       <dependency id="Rx-Main" version="[2.2.5,)" />
     </dependencies>
   </metadata>

--- a/Domain/CommandContext.cs
+++ b/Domain/CommandContext.cs
@@ -80,6 +80,11 @@ namespace Microsoft.Its.Domain
         /// </summary>
         public IClock Clock { get; set; }
 
+        /// <summary>
+        /// Gets the next etag in a deterministic, repeatable sequence using the specified target token as a seed.
+        /// </summary>
+        /// <param name="forTargetToken">A token representing the command target.</param>
+        /// <exception cref="System.ArgumentNullException"></exception>
         public string NextETag(string forTargetToken)
         {
             if (forTargetToken == null)
@@ -105,7 +110,7 @@ namespace Microsoft.Its.Domain
                                                       _ => new ETagSequence())
                                             .NextETagSequenceNumber();
 
-            var unhashedEtag = $"{Command.ETag}:{""} ({sequence})";
+            var unhashedEtag = $"{Command.ETag}:{forTargetToken} ({sequence})";
 
             var hashedEtag = unhashedEtag.ToETag();
 


### PR DESCRIPTION
This corrects a regression that was introduced in 0.13.3-beta. This may affect commands that were scheduled without code to explicitly set their etags, i.e. using Its.Domain's default etag strategy. 

The impact will be a potential duplication on retry for some failed commands. A command will be affected if all of the following are true:

* The command was scheduled during handling of a scheduled command.
* Its etag was not explicitly set.
* It was originally scheduled using v0.13.3-beta.
* It failed on delivery and was set to be retried.
* The retry occurred using version 0.15.10-beta or later.


  