### PR TITLE
Child command schedule on the same clock

### DIFF
--- a/AssemblyVersion.cs
+++ b/AssemblyVersion.cs
@@ -9,4 +9,4 @@ using System.Reflection;
 [assembly: CLSCompliant(true)]
 
 // Edit these for each release + update dependencies in .nuspec files
-[assembly: AssemblyInformationalVersion("0.15.10-beta")]
+[assembly: AssemblyInformationalVersion("0.16.0-beta")]

--- a/Domain.Api/Domain.Api.nuspec
+++ b/Domain.Api/Domain.Api.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>webapi DDD CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.15.10-beta,1)" />
+      <dependency id="Its.Domain" version="[0.16.0-beta,1)" />
       <dependency id="Microsoft.AspNet.WebApi" version="[5.1.2,)"  />
       <dependency id="Rx-Main" version="[2.2.5,)"   />
     </dependencies>

--- a/Domain.Sql/CommandScheduler/SqlCommandSchedulerPipelineInitializer{T}.cs
+++ b/Domain.Sql/CommandScheduler/SqlCommandSchedulerPipelineInitializer{T}.cs
@@ -52,7 +52,8 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
                             ? Domain.Clock.Create(() => cmd.DueTime.Value)
                             : cmd.Clock;
 
-            using (CommandContext.Establish(cmd.Command, clock))
+
+            using (CommandContext.Establish(cmd.Command, clock, cmd.Clock))
             {
                 await next(cmd);
 

--- a/Domain.Sql/Domain.Sql.nuspec
+++ b/Domain.Sql/Domain.Sql.nuspec
@@ -11,7 +11,7 @@
     <copyright>Copyright 2016</copyright>
     <tags>SQL CQRS Its.Cqrs event-sourcing</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.15.10-beta,1)" />
+      <dependency id="Its.Domain" version="[0.16.0-beta,1)" />
       <dependency id="EntityFramework" version="[6.1.3,)" />
       <dependency id="Its.Validation" version="[1.1.5,2.0)" />
     </dependencies>

--- a/Domain.Testing/Domain.Testing.nuspec
+++ b/Domain.Testing/Domain.Testing.nuspec
@@ -11,8 +11,8 @@
     <copyright>Copyright 2016</copyright>
     <tags>testing CQRS Its.Cqrs</tags>
     <dependencies>
-      <dependency id="Its.Domain" version="[0.15.10-beta,1)" />
-      <dependency id="Its.Domain.Sql" version="[0.15.10-beta,1)" />
+      <dependency id="Its.Domain" version="[0.16.0-beta,1)" />
+      <dependency id="Its.Domain.Sql" version="[0.16.0-beta,1)" />
       <dependency id="Rx-Main" version="[2.2.5,)" />
     </dependencies>
   </metadata>

--- a/Domain/Clock.cs
+++ b/Domain/Clock.cs
@@ -75,6 +75,11 @@ namespace Microsoft.Its.Domain
         }
 
         /// <summary>
+        /// The clock of the command who scheduled the command
+        /// </summary>
+        public static IClock ParentClock => CommandContext.Current != null ? CommandContext.Current.ParentClock : current;
+
+        /// <summary>
         /// Creates an <see cref="IClock" /> instance that calls the provided delegate to return the current time.
         /// </summary>
         public static IClock Create(Func<DateTimeOffset> now) => new AnonymousClock(now);

--- a/Domain/CommandContext.cs
+++ b/Domain/CommandContext.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Its.Domain
         /// </summary>
         /// <param name="command">The command.</param>
         /// <param name="clock">The clock used by the command and any events that result.</param>
-        public static CommandContext Establish(ICommand command, IClock clock = null)
+        /// <param name="parentClock">The clock of the command who scheduled this command</param>
+        public static CommandContext Establish(ICommand command, IClock clock = null, IClock parentClock = null)
         {
             var current = Current;
 
@@ -53,7 +54,8 @@ namespace Microsoft.Its.Domain
                 current = new CommandContext
                 {
                     // override the domain clock if a clock is provided
-                    Clock = clock ?? Domain.Clock.Current
+                    Clock = clock ?? Domain.Clock.Current,
+                    ParentClock = parentClock
                 };
 
                 CallContext.LogicalSetData(callContextKey, current.Id);
@@ -79,6 +81,11 @@ namespace Microsoft.Its.Domain
         /// Gets or sets the clock used within the command context.
         /// </summary>
         public IClock Clock { get; set; }
+
+        /// <summary>
+        /// Gets the parent clock used within the command context.
+        /// </summary>
+        public IClock ParentClock { get; set; }
 
         /// <summary>
         /// Gets the next etag in a deterministic, repeatable sequence using the specified target token as a seed.

--- a/Domain/Scheduling/ScheduledCommand{T}.cs
+++ b/Domain/Scheduling/ScheduledCommand{T}.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Its.Domain
 
             Command = command;
             TargetId = targetId;
-            DueTime = dueTime;
+            DueTime = dueTime ?? Domain.Clock.Current.Now();
             DeliveryPrecondition = deliveryPrecondition;
-            Clock = clock;
+            Clock = clock ?? Domain.Clock.ParentClock;
 
             this.EnsureCommandHasETag();
         }


### PR DESCRIPTION
If a command scheduled another command, due to the anonymous clock (used to freeze time).
The new command will be created on the anonymous clock and then fallback to default clock.

The solution is passing the origin clock down, called parentclock in the code, and when
scheduled new command, try to use it instead.