### PR TITLE
treat compiler warnings as errors in the release build

### DIFF
--- a/Domain.Api/Domain.Api.csproj
+++ b/Domain.Api/Domain.Api.csproj
@@ -38,6 +38,7 @@
     <DocumentationFile>bin\Release\Microsoft.Its.Domain.Api.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>false</RunCodeAnalysis>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Its.Validation, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Domain.Sql/Domain.Sql.csproj
+++ b/Domain.Sql/Domain.Sql.csproj
@@ -40,6 +40,7 @@
     <DocumentationFile>bin\Release\Microsoft.Its.Domain.Sql.xml</DocumentationFile>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <NoWarn />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/Domain.Testing/Domain.Testing.csproj
+++ b/Domain.Testing/Domain.Testing.csproj
@@ -38,6 +38,7 @@
     <DocumentationFile>bin\Release\Microsoft.Its.Domain.Testing.xml</DocumentationFile>
     <NoWarn>
     </NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -37,6 +37,7 @@
     <DocumentationFile>bin\Release\Microsoft.Its.Domain.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
     <RunCodeAnalysis>false</RunCodeAnalysis>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Its.Validation, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
The release build is the one that AppVeyor builds. My goal in not turning this on in the debug build is to keep the developer experience as fast as possible. 