### PR TITLE
Fix issue 182

### DIFF
--- a/Domain.Api.Tests/CommandDispatchTests.cs
+++ b/Domain.Api.Tests/CommandDispatchTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Its.Domain.Api.Tests
             var orderId = Any.Guid();
 
             var response = await testApi.GetClient()
-                                        .PostAsJsonAsync($"http://contoso.com/orders/createorder/{orderId}", new CreateOrder(Any.FullName()));
+                                        .PostAsJsonAsync($"http://contoso.com/orders/createorder/{orderId}", new CreateOrder(orderId, Any.FullName()));
 
             response.ShouldSucceed(HttpStatusCode.Created);
         }
@@ -184,11 +184,11 @@ namespace Microsoft.Its.Domain.Api.Tests
 
             var orderId = Any.Guid();
             await testApi.GetClient()
-                         .PostAsJsonAsync($"http://contoso.com/orders/createorder/{orderId}", new CreateOrder(Any.FullName()));
+                         .PostAsJsonAsync($"http://contoso.com/orders/createorder/{orderId}", new CreateOrder(orderId, Any.FullName()));
 
             // act
             var response = await testApi.GetClient()
-                                        .PostAsJsonAsync($"http://contoso.com/orders/createorder/{orderId}", new CreateOrder(Any.FullName()));
+                                        .PostAsJsonAsync($"http://contoso.com/orders/createorder/{orderId}", new CreateOrder(orderId, Any.FullName()));
 
             // assert
             response.ShouldFailWith(HttpStatusCode.Conflict);

--- a/Domain.Api/DomainApiController.cs
+++ b/Domain.Api/DomainApiController.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Its.Domain.Api
             [FromBody] JObject command)
         {
             var c = CreateCommand(commandName, command);
-            c.AggregateId = id;
 
             var ctor = typeof (TAggregate).GetConstructor(new[] { ((object) c).GetType() });
 

--- a/Domain.Sql.Tests/SqlCommandSchedulerClockTests.cs
+++ b/Domain.Sql.Tests/SqlCommandSchedulerClockTests.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using FluentAssertions;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Its.Log.Instrumentation;
 using Microsoft.Its.Domain.Tests;
 using Microsoft.Its.Recipes;
 using NCrunch.Framework;
@@ -16,6 +14,7 @@ using NUnit.Framework;
 using Test.Domain.Ordering;
 using static Microsoft.Its.Domain.Tests.CurrentConfiguration;
 using static Microsoft.Its.Domain.Sql.Tests.TestDatabases;
+using static Microsoft.Its.Domain.Tests.NonEventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Sql.Tests
 {

--- a/Domain.Sql.Tests/SqlCommandSchedulerTests_NonEventSourced.cs
+++ b/Domain.Sql.Tests/SqlCommandSchedulerTests_NonEventSourced.cs
@@ -12,6 +12,7 @@ using Microsoft.Its.Recipes;
 using NUnit.Framework;
 using static Microsoft.Its.Domain.Tests.CurrentConfiguration;
 using static Microsoft.Its.Domain.Sql.Tests.TestDatabases;
+using static Microsoft.Its.Domain.Tests.NonEventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Sql.Tests
 {

--- a/Domain.Sql/CommandScheduler/SqlCommandSchedulerExtensions.cs
+++ b/Domain.Sql/CommandScheduler/SqlCommandSchedulerExtensions.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
         /// </summary>
         internal static IScheduledCommand<TAggregate> ToScheduledCommand<TAggregate>(
             this ScheduledCommand scheduled)
+            where TAggregate : class
         {
             var json = scheduled.SerializedCommand;
 
@@ -42,7 +43,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
             command.DueTime = scheduled.DueTime;
             command.SequenceNumber = scheduled.SequenceNumber;
             command.NumberOfPreviousAttempts = scheduled.Attempts;
-            
+
             return command;
         }
     }

--- a/Domain.Sql/CommandScheduler/Storage.cs
+++ b/Domain.Sql/CommandScheduler/Storage.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Its.Domain.Sql.CommandScheduler
         internal static async Task DeserializeAndDeliverScheduledCommand<TAggregate>(
             ScheduledCommand scheduled,
             ICommandDeliverer<TAggregate> scheduler)
+            where TAggregate : class
         {
             try
             {

--- a/Domain.Testing.Tests/ScenarioBuilderWithInMemoryEventStoreTests.cs
+++ b/Domain.Testing.Tests/ScenarioBuilderWithInMemoryEventStoreTests.cs
@@ -25,10 +25,7 @@ namespace Microsoft.Its.Domain.Testing.Tests
             var scenario = CreateScenarioBuilder().Prepare();
 
             var id = Any.Guid();
-            scenario.SaveAsync(new Order(new CreateOrder(Any.FullName())
-            {
-                AggregateId = id
-            })).Wait();
+            scenario.SaveAsync(new Order(new CreateOrder(id, Any.FullName()))).Wait();
 
             var order = scenario.GetLatestAsync<Order>(id);
 

--- a/Domain.Testing.Tests/VirtualClockCommandSchedulingTests.cs
+++ b/Domain.Testing.Tests/VirtualClockCommandSchedulingTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Its.Domain.Tests;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;
 using Test.Domain.Ordering;
+using static Microsoft.Its.Domain.Tests.NonEventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Testing.Tests
 {
@@ -33,10 +34,7 @@ namespace Microsoft.Its.Domain.Testing.Tests
             var aggregateId = Any.Guid();
             await scheduler.Schedule(new CommandScheduled<Order>
             {
-                Command = new CreateOrder(Any.FullName())
-                {
-                    AggregateId = aggregateId
-                },
+                Command = new CreateOrder(aggregateId, Any.FullName()),
                 DueTime = Clock.Now().AddHours(1),
                 AggregateId = aggregateId
             });
@@ -60,10 +58,7 @@ namespace Microsoft.Its.Domain.Testing.Tests
 
             await scheduler.Schedule(new CommandScheduled<Order>
             {
-                Command = new CreateOrder(Any.FullName())
-                {
-                    AggregateId = aggregateId
-                },
+                Command = new CreateOrder(aggregateId, Any.FullName()),
                 DueTime = Clock.Now().AddHours(1),
                 AggregateId = aggregateId
             });

--- a/Domain.Testing/VirtualClock.cs
+++ b/Domain.Testing/VirtualClock.cs
@@ -269,6 +269,7 @@ namespace Microsoft.Its.Domain.Testing
             private IScheduledCommand<T> CreateNewScheduledCommandFrom<T>(
                 IScheduledCommand<T> scheduledCommand,
                 TimeSpan retryAfter)
+                where T : class
             {
                 return new ScheduledCommand<T>(
                     scheduledCommand.Command,

--- a/Domain.Tests/CommandContextTests.cs
+++ b/Domain.Tests/CommandContextTests.cs
@@ -92,9 +92,8 @@ namespace Microsoft.Its.Domain.Tests
             var customerId = Any.Guid();
             var bus = new InProcessEventBus();
             var orderRepository = new InMemoryEventSourcedRepository<Order>(bus: bus);
-            await orderRepository.Save(new Order(new CreateOrder(Any.FullName())
+            await orderRepository.Save(new Order(new CreateOrder(orderId, Any.FullName())
             {
-                AggregateId = orderId,
                 CustomerId = customerId
             }).Apply(new AddItem
             {

--- a/Domain.Tests/CommandFailedTests.cs
+++ b/Domain.Tests/CommandFailedTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;
+using static Microsoft.Its.Domain.Tests.NonEventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Tests
 {

--- a/Domain.Tests/CommandScheduled_T_Tests.cs
+++ b/Domain.Tests/CommandScheduled_T_Tests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;
 using Test.Domain.Ordering;
+using static Microsoft.Its.Domain.Tests.EventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Tests
 {

--- a/Domain.Tests/CommandSchedulerIdempotencyTests.cs
+++ b/Domain.Tests/CommandSchedulerIdempotencyTests.cs
@@ -73,10 +73,7 @@ namespace Microsoft.Its.Domain.Tests
 
             if (await repository.GetLatest(aggregateId) == null)
             {
-                await repository.Save(new Order(new CreateOrder(Any.FullName())
-                {
-                    AggregateId = aggregateId
-                }));
+                await repository.Save(new Order(new CreateOrder(aggregateId, Any.FullName())));
             }
 
             var command = new AddItem
@@ -111,7 +108,7 @@ namespace Microsoft.Its.Domain.Tests
             }
 
             var command = new ScheduledCommand<NonEventSourcedCommandTarget>(
-                new TestCommand(etag),
+                new NonEventSourcedCommandTarget.TestCommand(etag),
                 targetId,
                 dueTime,
                 deliveryDependsOn);

--- a/Domain.Tests/CommandSchedulerPipelineTests.cs
+++ b/Domain.Tests/CommandSchedulerPipelineTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Its.Domain.Tests
 
             var scheduler = configuration.CommandScheduler<Order>();
 
-            await scheduler.Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+            await scheduler.Schedule(new CreateOrder(Any.FullName()));
 
             scheduled.Should().BeTrue();
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Its.Domain.Tests
 
             var scheduler = Configuration.Current.CommandScheduler<Order>();
 
-            await scheduler.Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+            await scheduler.Schedule(new CreateOrder(Any.FullName()));
 
             checkpoints.Should()
                        .ContainInOrder("one", "two", "three", "four")
@@ -114,7 +114,7 @@ namespace Microsoft.Its.Domain.Tests
 
             scheduler = Configuration.Current.CommandScheduler<Order>();
 
-            await scheduler.Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+            await scheduler.Schedule(new CreateOrder(Any.FullName()));
 
             checkpoints.Should()
                        .ContainInOrder("one", "two", "three", "four")
@@ -130,9 +130,10 @@ namespace Microsoft.Its.Domain.Tests
             var log = new List<string>();
             using (LogTraceOutputTo(log))
             {
+                var targetId = Any.Word();
                 await Configuration.Current
                                    .CommandScheduler<NonEventSourcedCommandTarget>()
-                                   .Schedule(Any.Guid(), new CreateCommandTarget(Any.Word()));
+                                   .Schedule(targetId, new NonEventSourcedCommandTarget.CreateCommandTarget(targetId));
             }
 
             log.Count.Should().Be(4);
@@ -161,7 +162,7 @@ namespace Microsoft.Its.Domain.Tests
                 onDelivered: _ => onDeliveredWasCalled = true);
 
             await Configuration.Current.CommandScheduler<Order>()
-                               .Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+                               .Schedule(new CreateOrder(Any.FullName()));
 
             onSchedulingWasCalled.Should().BeTrue();
             onScheduledWasCalled.Should().BeTrue();
@@ -188,7 +189,7 @@ namespace Microsoft.Its.Domain.Tests
             using (LogTraceOutputTo(log))
             {
                 // send a command
-                await Configuration.Current.CommandScheduler<Order>().Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+                await Configuration.Current.CommandScheduler<Order>().Schedule(new CreateOrder(Any.FullName()));
             }
 
             log.Should().ContainSingle(e => e.Contains("[Scheduled]"));
@@ -210,7 +211,7 @@ namespace Microsoft.Its.Domain.Tests
             using (LogTraceOutputTo(log))
             {
                 // send a command
-                await Configuration.Current.CommandScheduler<Order>().Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+                await Configuration.Current.CommandScheduler<Order>().Schedule(new CreateOrder(Any.FullName()));
             }
 
             log.Should().ContainSingle(e => e.Contains("[Scheduled]"));
@@ -232,7 +233,7 @@ namespace Microsoft.Its.Domain.Tests
                 .Initialize(Configuration.Current);
 
             // send a command
-            await Configuration.Current.CommandScheduler<Order>().Schedule(Any.Guid(), new CreateOrder(Any.FullName()));
+            await Configuration.Current.CommandScheduler<Order>().Schedule(new CreateOrder(Any.FullName()));
 
             commandsScheduled.Count.Should().Be(1);
         }

--- a/Domain.Tests/CommandSchedulingTests_EventSourced.cs
+++ b/Domain.Tests/CommandSchedulingTests_EventSourced.cs
@@ -280,9 +280,10 @@ namespace Microsoft.Its.Domain.Tests
             Guid? customerAccountId = null)
         {
             return new Order(
-                new CreateOrder(customerName ?? Any.FullName())
+                new CreateOrder(
+                    orderId ?? Any.Guid(),
+                    customerName ?? Any.FullName())
                 {
-                    AggregateId = orderId ?? Any.Guid(),
                     CustomerId = customerAccountId ?? Any.Guid()
                 })
                 .Apply(new AddItem

--- a/Domain.Tests/CommandSchedulingTests_NonEventSourced.cs
+++ b/Domain.Tests/CommandSchedulingTests_NonEventSourced.cs
@@ -10,6 +10,7 @@ using Microsoft.Its.Domain.Testing;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;
 using static Microsoft.Its.Domain.Tests.CurrentConfiguration;
+using static Microsoft.Its.Domain.Tests.NonEventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Tests
 {

--- a/Domain.Tests/ConstructorCommandTests.cs
+++ b/Domain.Tests/ConstructorCommandTests.cs
@@ -27,10 +27,7 @@ namespace Microsoft.Its.Domain.Tests
         public void ConstructorCommand_AggregateId_is_used_to_specify_the_new_instances_Id()
         {
             var id = Any.Guid();
-            var createOrder = new CreateOrder(Any.Paragraph(2))
-            {
-                AggregateId = id
-            };
+            var createOrder = new CreateOrder(id, Any.Paragraph(2));
             var order = new Order(createOrder);
 
             order.Id.Should().Be(id);

--- a/Domain.Tests/Domain.Tests.csproj
+++ b/Domain.Tests/Domain.Tests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Infrastructure\UseInMemoryCommandTargetStoreAttribute.cs" />
     <Compile Include="Infrastructure\UseInMemoryEventStoreAttribute.cs" />
     <Compile Include="Infrastructure\UseInMemoryReservationServiceAttribute.cs" />
+    <Compile Include="EventSourcedCommandTarget.cs" />
     <Compile Include="NonEventSourcedCommandTarget.cs" />
     <Compile Include="EventSourcedAggregateCommandTests.cs" />
     <Compile Include="ConfigurationContextTests.cs" />

--- a/Domain.Tests/EventSourcedAggregateCommandTests.cs
+++ b/Domain.Tests/EventSourcedAggregateCommandTests.cs
@@ -477,6 +477,13 @@ namespace Microsoft.Its.Domain.Tests
 
         public class ConstructorCommandWithDataAnnotations : ConstructorCommand<FakeAggregateWithEnactCommandConvention>
         {
+            public ConstructorCommandWithDataAnnotations(
+                Guid? aggregateId = null,
+                string etag = null) :
+                base(aggregateId ?? Guid.NewGuid(), etag)
+            {
+            }
+
             [Required]
             public string Name { get; set; }
 

--- a/Domain.Tests/NonEventSourcedCommandTargetTests.cs
+++ b/Domain.Tests/NonEventSourcedCommandTargetTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
+using static Microsoft.Its.Domain.Tests.NonEventSourcedCommandTarget;
 
 namespace Microsoft.Its.Domain.Tests
 {

--- a/Domain.Tests/ScheduledCommandTests.cs
+++ b/Domain.Tests/ScheduledCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Its.Recipes;
 using NUnit.Framework;

--- a/Domain/ConstructorCommand{T}.cs
+++ b/Domain/ConstructorCommand{T}.cs
@@ -17,19 +17,33 @@ namespace Microsoft.Its.Domain
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstructorCommand{T}"/> class.
         /// </summary>
-        protected ConstructorCommand(string etag = null) : base(etag)
+        protected ConstructorCommand(Guid aggregateId, string etag = null) : base(etag)
         {
-            AggregateId = Guid.NewGuid();
+            AggregateId = aggregateId;
         }
 
         /// <summary>
-        /// Gets or sets the aggregate identifier to be used for the new instance of <typeparamref name="T" />.
+        /// Initializes a new instance of the <see cref="ConstructorCommand{T}"/> class.
         /// </summary>
-        /// <value>
-        /// The aggregate identifier.
-        /// </value>
-        public Guid AggregateId { get; set; }
-   
+        protected ConstructorCommand(string targetId, string etag = null) : base(etag)
+        {
+            if (targetId == null)
+            {
+                throw new ArgumentNullException(nameof(targetId));
+            }
+            TargetId = targetId;
+        }
+
+        /// <summary>
+        /// Gets the identifier to be used for the new instance of <typeparamref name="T" />.
+        /// </summary>
+        public Guid AggregateId { get; }
+
+        /// <summary>
+        /// Gets the identifier to be used for the new instance of <typeparamref name="T" />.
+        /// </summary>
+        public string TargetId { get; }
+
         /// <summary>
         /// If set, requires that the command be applied to this version of the aggregate; otherwise, <see cref="Command{TAggregate}.ApplyTo" /> will throw..
         /// </summary>
@@ -43,7 +57,7 @@ namespace Microsoft.Its.Domain
             }
             set
             {
-                throw new InvalidOperationException("ConstructorCommand<T> can only be applied at version 0 of an aggregate.");
+                throw new InvalidOperationException($"{nameof(ConstructorCommand<T>)} can only be applied at version 0 of an aggregate.");
             }
         }
     }

--- a/Domain/Scheduling/CommandScheduler.cs
+++ b/Domain/Scheduling/CommandScheduler.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Its.Domain
             DateTimeOffset? dueTime = null,
             IEvent deliveryDependsOn = null,
             IClock clock = null)
-            where TCommand : ICommand<TAggregate>
+            where TCommand : ICommand<TAggregate> 
+            where TAggregate : class
         {
             var scheduledCommand = new ScheduledCommand<TAggregate>(
                 command,
@@ -49,7 +50,8 @@ namespace Microsoft.Its.Domain
             DateTimeOffset? dueTime = null,
             IPrecondition deliveryDependsOn = null,
             IClock clock = null)
-            where TCommand : ICommand<TTarget>
+            where TCommand : ICommand<TTarget> 
+            where TTarget : class
         {
             var scheduledCommand = new ScheduledCommand<TTarget>(
                 command,
@@ -76,7 +78,7 @@ namespace Microsoft.Its.Domain
         {
             return await scheduler.Schedule(
                 command: command,
-                targetId: command.AggregateId.ToString(),
+                targetId: command.TargetId,
                 dueTime: dueTime,
                 deliveryDependsOn: deliveryDependsOn,
                 clock: clock);

--- a/Domain/Scheduling/CommandScheduler.cs
+++ b/Domain/Scheduling/CommandScheduler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Its.Domain
         {
             return await scheduler.Schedule(
                 command: command,
-                targetId: command.TargetId,
+                targetId: command.TargetId ?? command.AggregateId.ToString(),
                 dueTime: dueTime,
                 deliveryDependsOn: deliveryDependsOn,
                 clock: clock);

--- a/Test domains/Ordering.Domain/Ordering/Commands/CreateOrder.cs
+++ b/Test domains/Ordering.Domain/Ordering/Commands/CreateOrder.cs
@@ -3,19 +3,25 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Its.Domain;
 using Its.Validation;
 using Its.Validation.Configuration;
+using Microsoft.Its.Domain;
+using Newtonsoft.Json;
 
 namespace Test.Domain.Ordering
 {
     [DebuggerStepThrough]
     public class CreateOrder : ConstructorCommand<Order>, ISpecifySchedulingBehavior
     {
-        public CreateOrder(string customerName, string etag = null) : base(etag)
+        [JsonConstructor]
+        public CreateOrder(Guid aggregateId, string customerName, string etag = null) : base(aggregateId, etag)
         {
             CustomerName = customerName;
             CustomerId = Guid.NewGuid();
+        }
+
+        public CreateOrder(string customerName, string etag = null) : this(Guid.NewGuid(), customerName, etag)
+        {
         }
 
         public string CustomerName { get; set; }


### PR DESCRIPTION
This fixes issue #182 by enforcing that `TargetId` or `AggregateId` are passed to the constructor of `ConstructorCommand<T>`, and then enforcing in the constructor of `ScheduledCommand<T>`  that `ScheduledCommand<T>.TargetId` / `AggregateId` matches `ScheduledCommand<T>.TargetId` / `AggregateId`.

This isn't ideal but a cleaner approach will have to wait until strings become the default for identifiers for event sourced aggregates (#26).