### PR TITLE
Respect user-defined serialization settings

### DIFF
--- a/Domain.Api.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Api.Tests/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -24,3 +25,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c5841523-9fcc-4955-81d0-0808f81e2b41")]
+[assembly: LevelOfParallelism(1)]

--- a/Domain.Sql.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Sql.Tests/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -13,3 +14,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("84a78ff9-04ef-4985-afe3-029580ba5cad")]
+[assembly: LevelOfParallelism(1)]

--- a/Domain.Sql/EventContractResolver.cs
+++ b/Domain.Sql/EventContractResolver.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Its.Domain.Sql
     [DebuggerStepThrough]
     public class EventContractResolver : DefaultContractResolver
     {
+        /// <inheritdoc />
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);

--- a/Domain.Sql/EventContractResolver.cs
+++ b/Domain.Sql/EventContractResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
@@ -12,22 +12,33 @@ namespace Microsoft.Its.Domain.Sql
     /// Helps deserialize domain events when the body does not contain certain properties, which are pulled from SQL table columns instead.
     /// </summary>
     [DebuggerStepThrough]
-    internal class EventContractResolver : Serialization.OptionalContractResolver
+    public class EventContractResolver : DefaultContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
 
-            if (typeof (Event).IsAssignableFrom(property.DeclaringType)
+            ApplyRulesToProperty(property);
+
+            return property;
+        }
+
+        /// <summary>
+        /// Applies rules for serializing events to the specified property.
+        /// </summary>
+        /// <param name="property">The property to apply rules to.</param>
+        public static void ApplyRulesToProperty(JsonProperty property)
+        {
+            Serialization.OptionalContractResolver.ApplyRulesToProperty(property);
+
+            if (typeof(Event).IsAssignableFrom(property.DeclaringType)
                 && (property.PropertyName == "SequenceNumber" ||
                     property.PropertyName == "Timestamp" ||
-                    property.PropertyName == "AggregateId" || 
+                    property.PropertyName == "AggregateId" ||
                     property.PropertyName == "ETag"))
             {
                 property.Ignored = true;
             }
-
-            return property;
         }
     }
 }

--- a/Domain.Sql/EventExtensions.cs
+++ b/Domain.Sql/EventExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Its.Domain.Sql
         private static readonly Lazy<JsonSerializerSettings> serializerSettings = new Lazy<JsonSerializerSettings>(() =>
         {
             var settings = Serializer.CloneSettings();
-            settings.ContractResolver = new EventContractResolver();
+            settings.ContractResolver = Serializer.AreDefaultSerializerSettingsConfigured ? new EventContractResolver() : settings.ContractResolver;
             return settings;
         });
 

--- a/Domain.Testing.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Testing.Tests/Properties/AssemblyInfo.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -24,3 +25,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1181c564-15b8-480d-abbe-14d4841af415")]
+[assembly: LevelOfParallelism(1)]

--- a/Domain.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Tests/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -13,3 +14,4 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("71eaf469-9e33-447b-956e-f38a2cd25ebd")]
+[assembly: LevelOfParallelism(1)]

--- a/Domain/Serialization/OptionalContractResolver.cs
+++ b/Domain/Serialization/OptionalContractResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
@@ -25,24 +25,33 @@ namespace Microsoft.Its.Domain.Serialization
         /// </returns>
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
-            JsonProperty property = base.CreateProperty(member, memberSerialization);
+            var property = base.CreateProperty(member, memberSerialization);
 
-            if (typeof (IOptional).IsAssignableFrom(property.PropertyType))
+            ApplyRulesToProperty(property);
+
+            return property;
+        }
+
+        /// <summary>
+        /// Applies rules for serializing optional values to the specified property.
+        /// </summary>
+        /// <param name="property">The property to apply rules to.</param>
+        public static void ApplyRulesToProperty(JsonProperty property)
+        {
+            if (typeof(IOptional).IsAssignableFrom(property.PropertyType))
             {
                 property.NullValueHandling = NullValueHandling.Include;
 
                 property.ShouldSerialize = obj =>
                 {
-                    var optional = (IOptional) property.ValueProvider.GetValue(obj);
+                    var optional = (IOptional)property.ValueProvider.GetValue(obj);
                     return optional.IsSet;
                 };
             }
-            else if (typeof (IPrincipal).IsAssignableFrom(property.PropertyType))
+            else if (typeof(IPrincipal).IsAssignableFrom(property.PropertyType))
             {
                 property.Ignored = true;
             }
-
-            return property;
         }
     }
 }

--- a/Domain/Serialization/Serializer.cs
+++ b/Domain/Serialization/Serializer.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Its.Domain.Serialization
         
         private static JsonSerializerSettings settings;
 
+        internal static bool AreDefaultSerializerSettingsConfigured;
+
         /// <summary>
         /// Gets or sets the default settings for the JSON serializer.
         /// </summary>
@@ -65,6 +67,7 @@ namespace Microsoft.Its.Domain.Serialization
                 }
 
                 settings = value;
+                AreDefaultSerializerSettingsConfigured = false;
             }
         }
 
@@ -90,6 +93,8 @@ namespace Microsoft.Its.Domain.Serialization
 
             Settings.Converters.Add(new OptionalConverter());
             Settings.Converters.Add(new UriConverter());
+
+            AreDefaultSerializerSettingsConfigured = true;
         }
 
         /// <summary>

--- a/Test domains/Banking.Domain.Tests/Properties/AssemblyInfo.cs
+++ b/Test domains/Banking.Domain.Tests/Properties/AssemblyInfo.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
+using NUnit.Framework;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Banking.Domain.Tests")]
@@ -16,7 +17,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: LevelOfParallelism(1)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Previous Visual Studio 2015
+
 install:
   - nuget-restore.cmd
 


### PR DESCRIPTION
fixes: https://github.com/jonsequitur/Its.Cqrs/issues/196

- Right now, we are blindly overwriting ContractResolver with a new instance of EventContractResolver
- Thus, if user specifies serialization settings, the ContractResolver piece of those settings are not being respected.  This is problematic if the ContractResolver is doing something important (e.g. overriding CreateConstructorParameters to deal with constructors)
- If the user specifies their own serialization settings, it's my belief that they should fully own the consequences (e.g. not serializing IPrincipal).  
- Extracting "rules" from EventContractResolver and OptionalContractResolver into callable methods enables users to incorporate these rules in their own contract resolver