### PR TITLE
disable parallelism across assemblies

### DIFF
--- a/Domain.Api.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Api.Tests/Properties/AssemblyInfo.cs
@@ -1,12 +1,11 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using NUnit.Framework;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Its.Domain.Api.Tests")]
@@ -18,11 +17,10 @@ using NUnit.Framework;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c5841523-9fcc-4955-81d0-0808f81e2b41")]
-[assembly: LevelOfParallelism(1)]

--- a/Domain.Sql.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Sql.Tests/Properties/AssemblyInfo.cs
@@ -1,11 +1,10 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
-using NUnit.Framework;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Its.Domain.Sql.Tests")]
@@ -14,4 +13,3 @@ using NUnit.Framework;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("84a78ff9-04ef-4985-afe3-029580ba5cad")]
-[assembly: LevelOfParallelism(1)]

--- a/Domain.Testing.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Testing.Tests/Properties/AssemblyInfo.cs
@@ -1,12 +1,11 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using NUnit.Framework;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Domain.Testing.Tests")]
@@ -18,11 +17,10 @@ using NUnit.Framework;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1181c564-15b8-480d-abbe-14d4841af415")]
-[assembly: LevelOfParallelism(1)]

--- a/Domain.Tests/Properties/AssemblyInfo.cs
+++ b/Domain.Tests/Properties/AssemblyInfo.cs
@@ -1,11 +1,10 @@
-// Copyright (c) Microsoft. All rights reserved. 
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
 using System.Runtime.InteropServices;
-using NUnit.Framework;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Its.Domain.Tests")]
@@ -14,4 +13,3 @@ using NUnit.Framework;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("71eaf469-9e33-447b-956e-f38a2cd25ebd")]
-[assembly: LevelOfParallelism(1)]

--- a/Test domains/Banking.Domain.Tests/Properties/AssemblyInfo.cs
+++ b/Test domains/Banking.Domain.Tests/Properties/AssemblyInfo.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
-using NUnit.Framework;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -21,4 +20,3 @@ using NUnit.Framework;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-[assembly: LevelOfParallelism(1)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Previous Visual Studio 2015
+image: Visual Studio 2015
 
 install:
   - nuget-restore.cmd
@@ -10,7 +10,5 @@ build:
   project: Its.Cqrs.sln
   publish_nuget: true
 
-test:
-  assemblies:
-    - '**\*Tests.dll'
-
+test_script:
+- ps: nunit3-console (ls . -filter '*.Tests.dll' -r | ?{$_.FullName.Contains('bin\Release\')}  | sort-object -Unique -Property Name | % FullName) --agents=1 --result=myresults.xml`;format=AppVeyor


### PR DESCRIPTION
- By default, NUnit doesn't run tests in parallel within an assembly.  Removing AssemblyInfo.cs directives because those aren't (according to documentation) doing anything.  Those control the degree of parallelism for tests that opt-into parallelism
- NUnit does run tests across assemblies in parallel.  AppVeyor.yml now calls the NUnit CLI directly, setting agents=1 to disable that
- No longer using the "Previous" VS 2015 build image.  Now using the "current" one.
- Build still fails on a single unit test.  This same unit test consistently fails with different NUnit CLI arguments, so I think it might be a legitimate failure:

```
1) Error : Microsoft.Its.Domain.Sql.Tests.DiagnosticTests.Sensor_can_be_used_to_check_read_model_catchup_status
System.AggregateException : One or more errors occurred.
  ----> System.InvalidOperationException : The cast to value type 'System.Int64' failed because the materialized value is null. Either the result type's generic parameter or the query must use a nullable type.
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Microsoft.Its.Domain.Sql.Tests.DiagnosticTests.Sensor_can_be_used_to_check_read_model_catchup_status() in C:\projects\its-cqrs\Domain.Sql.Tests\DiagnosticTests.cs:line 16
--InvalidOperationException
   at System.Data.Entity.Core.Common.Internal.Materialization.Shaper.ErrorHandlingValueReader`1.GetValue(DbDataReader reader, Int32 ordinal)
   at lambda_method(Closure , Shaper )
   at System.Data.Entity.Core.Common.Internal.Materialization.Coordinator`1.ReadNextElement(Shaper shaper)
   at System.Data.Entity.Core.Common.Internal.Materialization.Shaper`1.SimpleEnumerator.<MoveNextAsync>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Data.Entity.Internal.LazyAsyncEnumerator`1.<FirstMoveNextAsync>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Data.Entity.Infrastructure.IDbAsyncEnumerableExtensions.<SingleAsync>d__2d`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Its.Domain.Sql.Sensors.<CatchupStatus>d__4.MoveNext() in C:\projects\its-cqrs\Domain.Sql\Sensors.cs:line 42
```
